### PR TITLE
`saveState()` is now deprecated, using `pushDefaultState()` instead

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -42,9 +42,9 @@ label{
 	<br>
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
-	<button onclick="cameraControls.reset( true )">reset</button>
 	<br>
-	<button onclick="cameraControls.saveState()">saveState</button>
+	<button onclick="cameraControls.pushDefaultState()">set default state</button>
+	<button onclick="cameraControls.reset( true )">reset</button>
 	<br>
 	<button onclick="cameraControls.enabled = false;">disable mouse/touch controls</button>
 	<button onclick="cameraControls.enabled = true;">enable mouse/touch controls</button>

--- a/examples/orthographic.html
+++ b/examples/orthographic.html
@@ -37,9 +37,9 @@ a{
 	<br>
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
-	<button onclick="cameraControls.reset( true )">reset</button>
 	<br>
-	<button onclick="cameraControls.saveState()">saveState</button>
+	<button onclick="cameraControls.pushDefaultState()">set default state</button>
+	<button onclick="cameraControls.reset( true )">reset</button>
 	<br>
 	<button onclick="cameraControls.enabled = false;">disable mouse/touch controls</button>
 	<button onclick="cameraControls.enabled = true;">enable mouse/touch controls</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,6 +2744,33 @@
         "rollup-pluginutils": "^1.5.0"
       }
     },
+    "rollup-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.3.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+          "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+          "dev": true
+        },
+        "rollup-pluginutils": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
+          "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^0.5.2",
+            "micromatch": "^2.3.11"
+          }
+        }
+      }
+    },
     "rollup-pluginutils": {
       "version": "1.5.2",
       "resolved": "http://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-preset-env": "1.6.0",
     "rollup": "^0.45.2",
     "rollup-plugin-babel": "2.7.1",
+    "rollup-plugin-json": "^3.1.0",
     "rollup-watch": "^4.3.1",
     "uglify-js": "^3.0.25"
   },

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Move forward / backward.
 
 Fit the viewport to the object bounding box or the bounding box itself. paddings are in unit.
 
-#### `saveState()`
+#### `pushDefaultState()` ( formerly `saveState()` )
 
 Set current camera position as the default position
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from 'rollup-plugin-babel'
+import json from 'rollup-plugin-json'
 
 const license = `/*!
  * camera-controls
@@ -12,6 +13,7 @@ export default {
 	indent: '\t',
 	sourceMap: false,
 	plugins: [
+		json(),
 		babel( {
 			exclude: 'node_modules/**',
 			presets: [


### PR DESCRIPTION
手始めに、変数名を書き換えてしまいました。
ここから、 `target` , `position` , `zoom` をひとまとめにした構造体的な概念を作って、いろいろな形で使えるようにできればとにらんでいます。

## I did a change that might cause compatibility break

- `saveState()` -> `pushDefaultState()`
  - I don't know the context how `saveState` named, but I'm so confused by the name.
    I think `pushDefaultState` is more proper to this procedure.
  - There still are older one, along with deprecation warning.
    (using `saveState()` on this revision doesn't kill you instantly 😇)

## Other internal variable changes:

- `target0`, `position0`, `zoom0` -> `defaultTarget`, `defaultPosition`, `defaultZoom`
  - I think it's more proper
- `state` (in mouse/touch context) -> `controlState`
  - since it's too ambiguous with other "state" concepts
- `STATE` enums -> `CONTROL_STATE`
  - same reason as above one

## JSON compatibility stuff

I changed the name of `target0`, `position0` as I said above, and these variables are exposed via JSON,
so I needed to add this section in order to support older JSONs:

https://github.com/FMS-Cat/camera-controls/blob/74bca5f50731d9ea514d26104c7b1ad49d41c390/src/camera-controls.js#L672-L676

It also adds version information into JSON and it's required to perform compat stuff,
so **don't forget to raise the version before publish these changes!**
（バージョンまわりのしきたりがわからなかったです🙇）