### PR TITLE
We should use Math.exp instead

### DIFF
--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -585,7 +585,7 @@ export default class CameraControls {
 		// var quat = new THREE.Quaternion().setFromUnitVectors( this.object.up, new THREE.Vector3( 0, 1, 0 ) );
 		// var quatInverse = quat.clone().inverse();
 
-		const dampingFactor = this.dampingFactor * delta / 0.016;
+		const dampingFactor = 1.0 - Math.exp( -this.dampingFactor * delta / 0.016 );
 		const deltaTheta  = this._sphericalEnd.theta  - this._spherical.theta;
 		const deltaPhi    = this._sphericalEnd.phi    - this._spherical.phi;
 		const deltaRadius = this._sphericalEnd.radius - this._spherical.radius;


### PR DESCRIPTION
current method we're doing interpolation at `update()` can do weird behavior under extreme situation (laggy environment like 10FPS, or higher damping factor such as `0.5` or `1.0` or w/e).
We should use `Math.exp` instead here, so it guarantees `target` / `spherical` to be converged to desired location (even if damping factor is `Infinity` )!

It has minor compatibility break (does different behavior under high damping factor) but I recommend to apply this change.

![background](https://user-images.githubusercontent.com/7824814/49067768-4dc3d380-f268-11e8-9b17-f412000002c7.png)
