### PR TITLE
Implemented `setLookAt` and `lerpLookAt`

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -44,7 +44,7 @@ label{
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
 	<br>
 	<button onclick="cameraControls.setPosition( new THREE.Vector3( -5, 2, 1 ), true )">move to ( -5, 2, 1 )</button>
-	<button onclick="cameraControls.setTarget( new THREE.Vector3( 3, -3, 0 ), true )">look at ( 3, -3, 0 )</button>
+	<button onclick="cameraControls.setTarget( new THREE.Vector3( 3, 0, -3 ), true )">look at ( 3, 0, -3 )</button>
 	<button onclick="cameraControls.setLookAt( new THREE.Vector3( 1, 2, 3 ), new THREE.Vector3( 1, 1, 0 ), true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
 	<br>
 	<button onclick="cameraControls.lerpLookAt( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( 1, 1, 0 ), new THREE.Vector3( 0, 2, 5 ), new THREE.Vector3( -1, 0, 0 ), Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -43,7 +43,9 @@ label{
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
 	<br>
-	<button onclick="cameraControls.setLookAt( new THREE.Vector3( 1, 2, 3 ), new THREE.Vector3( 1, 1, 0 ), Math.random(), true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
+	<button onclick="cameraControls.setPosition( new THREE.Vector3( -5, 2, 1 ), true )">move to ( -5, 2, 1 )</button>
+	<button onclick="cameraControls.setTarget( new THREE.Vector3( 3, -3, 0 ), true )">look at ( 3, -3, 0 )</button>
+	<button onclick="cameraControls.setLookAt( new THREE.Vector3( 1, 2, 3 ), new THREE.Vector3( 1, 1, 0 ), true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
 	<br>
 	<button onclick="cameraControls.lerpLookAt( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( 1, 1, 0 ), new THREE.Vector3( 0, 2, 5 ), new THREE.Vector3( -1, 0, 0 ), Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
 	<br>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -42,8 +42,12 @@ label{
 	<br>
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
-	<button onclick="cameraControls.reset( true )">reset</button>
 	<br>
+	<button onclick="cameraControls.setLookAt( new THREE.Vector3( 1, 2, 3 ), new THREE.Vector3( 1, 1, 0 ), Math.random(), true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
+	<br>
+	<button onclick="cameraControls.lerpLookAt( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( 1, 1, 0 ), new THREE.Vector3( 0, 2, 5 ), new THREE.Vector3( -1, 0, 0 ), Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
+	<br>
+	<button onclick="cameraControls.reset( true )">reset</button>
 	<button onclick="cameraControls.saveState()">saveState</button>
 	<br>
 	<button onclick="cameraControls.enabled = false;">disable mouse/touch controls</button>

--- a/readme.md
+++ b/readme.md
@@ -111,11 +111,11 @@ Same as `setLookAt` , but it interpolates between two states.
 
 `setLookAt` without `position` , Stay still at the position.
 
-#### `getPosition()`
+#### `getPosition( out )`
 
 Return its current position.
 
-#### `getTarget()`
+#### `getTarget( out )`
 
 Return its current gazing target.
 

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,30 @@ Move forward / backward.
 
 Fit the viewport to the object bounding box or the bounding box itself. paddings are in unit.
 
+#### `setLookAt( position, target, enableTransition )`
+
+It moves the camera into `position` , and also make it look at `target` .
+
+#### `lerpLookAt( positionA, targetA, positionB, targetB, x, enableTransition )`
+
+Same as `setLookAt` , but it interpolates between two states.
+
+#### `setPosition( position, enableTransition )`
+
+`setLookAt` without `target` , Stay gazing at the current target.
+
+#### `setTarget( target, enableTransition )`
+
+`setLookAt` without `position` , Stay still at the position.
+
+#### `getPosition()`
+
+Return its current position.
+
+#### `getTarget()`
+
+Return its current gazing target.
+
 #### `saveState()`
 
 Set current camera position as the default position

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -614,14 +614,14 @@ export default class CameraControls {
 
 	getTarget( out ) {
 
-		const _out = out.isVector3 ? out : new THREE.Vector3();
+		const _out = typeof out === 'object' && out.isVector3 ? out : new THREE.Vector3();
 		return _out.copy( this._targetEnd );
 
 	}
 
 	getPosition( out ) {
 
-		const _out = out.isVector3 ? out : new THREE.Vector3();
+		const _out = typeof out === 'object' && out.isVector3 ? out : new THREE.Vector3();
 		return _out.setFromSpherical( this._sphericalEnd ).add( this._targetEnd );
 
 	}

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -612,15 +612,17 @@ export default class CameraControls {
 
 	}
 
-	getTarget() {
+	getTarget( out ) {
 
-		return this._targetEnd.clone();
+		const _out = out.isVector3 ? out : new THREE.Vector3();
+		return _out.copy( this._targetEnd );
 
 	}
 
-	getPosition() {
+	getPosition( out ) {
 
-		return new Vector().setFromSpherical( this._sphericalEnd );
+		const _out = out.isVector3 ? out : new THREE.Vector3();
+		return _out.setFromSpherical( this._sphericalEnd );
 
 	}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -50,7 +50,7 @@ export default class CameraControls {
 		this.domElement = domElement;
 
 		// the location of focus, where the object orbits around
-		this.target = new THREE.Vector3();
+		this._target = new THREE.Vector3();
 		this._targetEnd = new THREE.Vector3();
 
 		// rotation
@@ -59,7 +59,7 @@ export default class CameraControls {
 		this._sphericalEnd = new THREE.Spherical().copy( this._spherical );
 
 		// reset
-		this._target0 = this.target.clone();
+		this._target0 = this._target.clone();
 		this._position0 = this.object.position.clone();
 		this._zoom0 = this.object.zoom;
 
@@ -287,7 +287,7 @@ export default class CameraControls {
 
 						if ( scope.object.isPerspectiveCamera ) {
 
-							const offset = _v3.copy( scope.object.position ).sub( scope.target );
+							const offset = _v3.copy( scope.object.position ).sub( scope._target );
 							// half of the fov is center to top of screen
 							const fovInRad = scope.object.fov * THREE.Math.DEG2RAD;
 							const targetDistance = offset.length() * Math.tan( ( fovInRad / 2 ) );
@@ -466,7 +466,7 @@ export default class CameraControls {
 
 		if ( ! enableTransition ) {
 
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 
 		}
 
@@ -484,7 +484,7 @@ export default class CameraControls {
 
 		if ( ! enableTransition ) {
 
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 
 		}
 
@@ -498,7 +498,7 @@ export default class CameraControls {
 
 		if ( ! enableTransition ) {
 
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 
 		}
 
@@ -562,7 +562,7 @@ export default class CameraControls {
 
 		if ( ! enableTransition ) {
 
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 			this._spherical.copy( this._sphericalEnd );
 
 		}
@@ -573,7 +573,7 @@ export default class CameraControls {
 
 	saveState() {
 
-		this._target0.copy( this.target );
+		this._target0.copy( this._target );
 		this._position0.copy( this.object.position );
 		this._zoom0 = this.object.zoom;
 
@@ -589,7 +589,7 @@ export default class CameraControls {
 		const deltaTheta  = this._sphericalEnd.theta  - this._spherical.theta;
 		const deltaPhi    = this._sphericalEnd.phi    - this._spherical.phi;
 		const deltaRadius = this._sphericalEnd.radius - this._spherical.radius;
-		const deltaTarget = new THREE.Vector3().subVectors( this._targetEnd, this.target );
+		const deltaTarget = new THREE.Vector3().subVectors( this._targetEnd, this._target );
 
 		if (
 			Math.abs( deltaTheta    ) > EPSILON ||
@@ -606,20 +606,20 @@ export default class CameraControls {
 				this._spherical.theta  + deltaTheta  * dampingFactor
 			);
 
-			this.target.add( deltaTarget.multiplyScalar( dampingFactor ) );
+			this._target.add( deltaTarget.multiplyScalar( dampingFactor ) );
 
 			this._needsUpdate = true;
 
 		} else {
 
 			this._spherical.copy( this._sphericalEnd );
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 
 		}
 
 		this._spherical.makeSafe();
-		this.object.position.setFromSpherical( this._spherical ).add( this.target );
-		this.object.lookAt( this.target );
+		this.object.position.setFromSpherical( this._spherical ).add( this._target );
+		this.object.lookAt( this._target );
 
 		const updated = this._needsUpdate;
 		this._needsUpdate = false;
@@ -679,7 +679,7 @@ export default class CameraControls {
 
 		if ( ! enableTransition ) {
 
-			this.target.copy( this._targetEnd );
+			this._target.copy( this._targetEnd );
 			this._spherical.copy( this._sphericalEnd );
 
 		}

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -596,7 +596,7 @@ export default class CameraControls {
 
 	setTarget( target, enableTransition ) {
 
-		this.setLookAt( new THREE.Vector3().setFromSpherical( this._sphericalEnd ), target, enableTransition );
+		this.setLookAt( this.getPosition(), target, enableTransition );
 
 	}
 
@@ -622,7 +622,7 @@ export default class CameraControls {
 	getPosition( out ) {
 
 		const _out = out.isVector3 ? out : new THREE.Vector3();
-		return _out.setFromSpherical( this._sphericalEnd );
+		return _out.setFromSpherical( this._sphericalEnd ).add( this._targetEnd );
 
 	}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -596,7 +596,7 @@ export default class CameraControls {
 
 	setTarget( target, enableTransition ) {
 
-		this.setLookAt( new Vector3.setFromSpherical( this._sphericalEnd ), target, enableTransition );
+		this.setLookAt( new THREE.Vector3().setFromSpherical( this._sphericalEnd ), target, enableTransition );
 
 	}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -620,7 +620,7 @@ export default class CameraControls {
 
 	getPosition() {
 
-		return this.object.position.clone();
+		return new Vector().setFromSpherical( this._sphericalEnd );
 
 	}
 


### PR DESCRIPTION
## New functions

- `setLookAt( position, target, enableTransition )`
  It moves the camera into `position` , and also make it look at `target` .
- `lerpLookAt( positionA, targetA, positionB, targetB, x, enableTransition )`
  Same as `setLookAt` , but it interpolates between two states.
- `setPosition( position, enableTransition )`
  `setLookAt` without `target` , Stay gazing the current target.
- `setTarget( target, enableTransition )`
  `setLookAt` without `position` , Stay still at the position.
- `getPosition()`
  Return its current position.
- `getTarget()`
  Return its current gazing target.

## Improved procedure

- I added the private function `_sanitizeSphericals()` .
  It clamps `_sphericalEnd.theta` into `0` ~ `TAU` and also make `_spherical` in range between `_sphericalEnd.theta - PI` ~ `_sphericalEnd.theta` + PI,
  It prevents spinning the camera more than `PI` .

## Also

- `target` is now `_target` (marked as private). Don't touch it