### PR TITLE
`setLookAt` / `lerpLookAt` now receives number literals instead of `THREE.Vector3`

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -43,11 +43,11 @@ label{
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
 	<br>
-	<button onclick="cameraControls.setPosition( [ -5, 2, 1 ], true )">move to ( -5, 2, 1 )</button>
-	<button onclick="cameraControls.setTarget( [ 3, 0, -3 ], true )">look at ( 3, 0, -3 )</button>
-	<button onclick="cameraControls.setLookAt( [ 1, 2, 3 ], [ 1, 1, 0 ], true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
+	<button onclick="cameraControls.setPosition( -5, 2, 1, true )">move to ( -5, 2, 1 )</button>
+	<button onclick="cameraControls.setTarget( 3, 0, -3, true )">look at ( 3, 0, -3 )</button>
+	<button onclick="cameraControls.setLookAt( 1, 2, 3, 1, 1, 0, true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
 	<br>
-	<button onclick="cameraControls.lerpLookAt( [ -2, 0, 0 ], [ 1, 1, 0 ], [ 0, 2, 5 ], [ -1, 0, 0 ], Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
+	<button onclick="cameraControls.lerpLookAt( -2, 0, 0, 1, 1, 0, 0, 2, 5, -1, 0, 0, Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
 	<br>
 	<button onclick="cameraControls.reset( true )">reset</button>
 	<button onclick="cameraControls.saveState()">saveState</button>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -43,11 +43,11 @@ label{
 	<button onclick="cameraControls.moveTo( 3, 5, 2, true )">move to( 3, 5, 2 )</button>
 	<button onclick="cameraControls.fitTo( mesh, true )">fit to the bounding box of the mesh</button>
 	<br>
-	<button onclick="cameraControls.setPosition( new THREE.Vector3( -5, 2, 1 ), true )">move to ( -5, 2, 1 )</button>
-	<button onclick="cameraControls.setTarget( new THREE.Vector3( 3, 0, -3 ), true )">look at ( 3, 0, -3 )</button>
-	<button onclick="cameraControls.setLookAt( new THREE.Vector3( 1, 2, 3 ), new THREE.Vector3( 1, 1, 0 ), true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
+	<button onclick="cameraControls.setPosition( [ -5, 2, 1 ], true )">move to ( -5, 2, 1 )</button>
+	<button onclick="cameraControls.setTarget( [ 3, 0, -3 ], true )">look at ( 3, 0, -3 )</button>
+	<button onclick="cameraControls.setLookAt( [ 1, 2, 3 ], [ 1, 1, 0 ], true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
 	<br>
-	<button onclick="cameraControls.lerpLookAt( new THREE.Vector3( -2, 0, 0 ), new THREE.Vector3( 1, 1, 0 ), new THREE.Vector3( 0, 2, 5 ), new THREE.Vector3( -1, 0, 0 ), Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
+	<button onclick="cameraControls.lerpLookAt( [ -2, 0, 0 ], [ 1, 1, 0 ], [ 0, 2, 5 ], [ -1, 0, 0 ], Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
 	<br>
 	<button onclick="cameraControls.reset( true )">reset</button>
 	<button onclick="cameraControls.saveState()">saveState</button>

--- a/readme.md
+++ b/readme.md
@@ -95,21 +95,21 @@ Move forward / backward.
 
 Fit the viewport to the object bounding box or the bounding box itself. paddings are in unit.
 
-#### `setLookAt( position, target, enableTransition )`
+#### `setLookAt( positionX, positionY, positionZ, targetX, targetY, targetZ, enableTransition )`
 
 It moves the camera into `position` , and also make it look at `target` .
 
-#### `lerpLookAt( positionA, targetA, positionB, targetB, x, enableTransition )`
+#### `lerpLookAt( positionAX, positionAY, positionAZ, targetAX, targetAY, targetAZ, positionBX, positionBY, positionBZ, targetBX, targetBY, targetBZ, x, enableTransition )`
 
 Same as `setLookAt` , but it interpolates between two states.
 
-#### `setPosition( position, enableTransition )`
+#### `setPosition( positionX, positionY, positionZ, enableTransition )`
 
-`setLookAt` without `target` , Stay gazing at the current target.
+`setLookAt` without target , Stay gazing at the current target.
 
-#### `setTarget( target, enableTransition )`
+#### `setTarget( targetX, targetY, targetZ, enableTransition )`
 
-`setLookAt` without `position` , Stay still at the position.
+`setLookAt` without position , Stay still at the position.
 
 #### `getPosition( out )`
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -542,8 +542,11 @@ export default class CameraControls {
 
 	setLookAt( position, target, enableTransition ) {
 
-		this._targetEnd.copy( target );
-		this._sphericalEnd.setFromVector3( _v3.subVectors( position, target ) );
+		const _position = toVector3( position );
+		const _target = toVector3( target );
+
+		this._targetEnd.copy( _target );
+		this._sphericalEnd.setFromVector3( _v3.subVectors( _position, _target ) );
 		this._sanitizeSphericals();
 
 		if ( ! enableTransition ) {
@@ -559,13 +562,18 @@ export default class CameraControls {
 
 	lerpLookAt( positionA, targetA, positionB, targetB, x, enableTransition ) {
 
-		const sphericalA = new THREE.Spherical().setFromVector3( _v3.subVectors( positionA, targetA ) );
-		const sphericalB = new THREE.Spherical().setFromVector3( _v3.subVectors( positionB, targetB ) );
+		const _positionA = toVector3( positionA );
+		const _targetA = toVector3( targetA );
+		const _positionB = toVector3( positionB );
+		const _targetB = toVector3( targetB );
+
+		const sphericalA = new THREE.Spherical().setFromVector3( _v3.subVectors( _positionA, _targetA ) );
+		const sphericalB = new THREE.Spherical().setFromVector3( _v3.subVectors( _positionB, _targetB ) );
 
 		const deltaTheta  = sphericalB.theta  - sphericalA.theta;
 		const deltaPhi    = sphericalB.phi    - sphericalA.phi;
 		const deltaRadius = sphericalB.radius - sphericalA.radius;
-		const deltaTarget = new THREE.Vector3().subVectors( targetB, targetA );
+		const deltaTarget = new THREE.Vector3().subVectors( _targetB, _targetA );
 
 		this._sphericalEnd.set(
 			sphericalA.radius + deltaRadius * x,
@@ -573,7 +581,7 @@ export default class CameraControls {
 			sphericalA.theta  + deltaTheta  * x
 		);
 
-		this._targetEnd.copy( targetA ).add( deltaTarget.multiplyScalar( x ) );
+		this._targetEnd.copy( _targetA ).add( deltaTarget.multiplyScalar( x ) );
 		
 		this._sanitizeSphericals();
 
@@ -755,6 +763,28 @@ export default class CameraControls {
 		this._spherical.theta += 2 * Math.PI * Math.round(
 			( this._sphericalEnd.theta - this._spherical.theta ) / ( 2 * Math.PI )
 		);
+
+	}
+
+}
+
+function toVector3( value ) {
+
+	if ( !value ) {
+
+		return null;
+
+	} else if ( value.isVector3 ) {
+
+		return value;
+
+	} else if ( Array.isArray( value ) ) {
+
+		return new THREE.Vector3().fromArray( value );
+
+	} else {
+
+		return new THREE.Vector3();
 
 	}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -546,7 +546,7 @@ export default class CameraControls {
 		const _target = toVector3( target );
 
 		this._targetEnd.copy( _target );
-		this._sphericalEnd.setFromVector3( _v3.subVectors( _position, _target ) );
+		this._sphericalEnd.setFromVector3( _position.sub( _target ) );
 		this._sanitizeSphericals();
 
 		if ( ! enableTransition ) {

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -1,5 +1,6 @@
 let THREE;
-let _v3;
+let _v3a;
+let _v3b;
 let _xColumn;
 let _yColumn;
 const EPSILON = 0.001;
@@ -18,7 +19,8 @@ export default class CameraControls {
 	static install( libs ) {
 
 		THREE = libs.THREE;
-		_v3 = new THREE.Vector3();
+		_v3a = new THREE.Vector3();
+		_v3b = new THREE.Vector3();
 		_xColumn = new THREE.Vector3();
 		_yColumn = new THREE.Vector3();
 
@@ -287,7 +289,7 @@ export default class CameraControls {
 
 						if ( scope.object.isPerspectiveCamera ) {
 
-							const offset = _v3.copy( scope.object.position ).sub( scope._target );
+							const offset = _v3a.copy( scope.object.position ).sub( scope._target );
 							// half of the fov is center to top of screen
 							const fovInRad = scope.object.fov * THREE.Math.DEG2RAD;
 							const targetDistance = offset.length() * Math.tan( ( fovInRad / 2 ) );
@@ -461,7 +463,7 @@ export default class CameraControls {
 		_xColumn.multiplyScalar(   x );
 		_yColumn.multiplyScalar( - y );
 
-		const offset = _v3.copy( _xColumn ).add( _yColumn );
+		const offset = _v3a.copy( _xColumn ).add( _yColumn );
 		this._targetEnd.add( offset );
 
 		if ( ! enableTransition ) {
@@ -476,11 +478,11 @@ export default class CameraControls {
 
 	forward( distance, enableTransition ) {
 
-		_v3.setFromMatrixColumn( this.object.matrix, 0 );
-		_v3.crossVectors( this.object.up, _v3 );
-		_v3.multiplyScalar( distance );
+		_v3a.setFromMatrixColumn( this.object.matrix, 0 );
+		_v3a.crossVectors( this.object.up, _v3a );
+		_v3a.multiplyScalar( distance );
 
-		this._targetEnd.add( _v3 );
+		this._targetEnd.add( _v3a );
 
 		if ( ! enableTransition ) {
 
@@ -521,7 +523,7 @@ export default class CameraControls {
 		const paddingTop = options.paddingTop || 0;
 
 		const boundingBox = objectOrBox3.isBox3 ? objectOrBox3.clone() : new THREE.Box3().setFromObject( objectOrBox3 );
-		const size = boundingBox.getSize( _v3 );
+		const size = boundingBox.getSize( _v3a );
 		const boundingWidth  = size.x + paddingLeft + paddingRight;
 		const boundingHeight = size.y + paddingTop + paddingBottom;
 		const boundingDepth = size.z;
@@ -529,7 +531,7 @@ export default class CameraControls {
 		const distance = this.getDistanceToFit( boundingWidth, boundingHeight, boundingDepth );
 		this.dollyTo( distance, enableTransition );
 
-		const boundingBoxCenter = boundingBox.getCenter( _v3 );
+		const boundingBoxCenter = boundingBox.getCenter( _v3a );
 		const cx = boundingBoxCenter.x - ( paddingLeft * 0.5 - paddingRight * 0.5 );
 		const cy = boundingBoxCenter.y + ( paddingTop * 0.5 - paddingBottom * 0.5 );
 		const cz = boundingBoxCenter.z;
@@ -540,13 +542,17 @@ export default class CameraControls {
 
 	}
 
-	setLookAt( position, target, enableTransition ) {
+	setLookAt(
+		positionX, positionY, positionZ,
+		targetX, targetY, targetZ,
+		enableTransition
+	) {
 
-		const _position = toVector3( position );
-		const _target = toVector3( target );
+		const position = _v3a.set( positionX, positionY, positionZ );
+		const target = _v3b.set( targetX, targetY, targetZ );
 
-		this._targetEnd.copy( _target );
-		this._sphericalEnd.setFromVector3( _position.sub( _target ) );
+		this._targetEnd.copy( target );
+		this._sphericalEnd.setFromVector3( position.sub( target ) );
 		this._sanitizeSphericals();
 
 		if ( ! enableTransition ) {
@@ -560,20 +566,27 @@ export default class CameraControls {
 
 	}
 
-	lerpLookAt( positionA, targetA, positionB, targetB, x, enableTransition ) {
+	lerpLookAt(
+		positionAX, positionAY, positionAZ,
+		targetAX, targetAY, targetAZ,
+		positionBX, positionBY, positionBZ,
+		targetBX, targetBY, targetBZ,
+		x, enableTransition
+	) {
 
-		const _positionA = toVector3( positionA );
-		const _targetA = toVector3( targetA );
-		const _positionB = toVector3( positionB );
-		const _targetB = toVector3( targetB );
+		const positionA = _v3a.set( positionAX, positionAY, positionAZ );
+		const targetA = _v3b.set( targetAX, targetAY, targetAZ );
+		const sphericalA = new THREE.Spherical().setFromVector3( positionA.sub( targetA ) );
 
-		const sphericalA = new THREE.Spherical().setFromVector3( _v3.subVectors( _positionA, _targetA ) );
-		const sphericalB = new THREE.Spherical().setFromVector3( _v3.subVectors( _positionB, _targetB ) );
+		const targetB = _v3a.set( targetBX, targetBY, targetBZ );
+		this._targetEnd.copy( targetA ).lerp( targetB, x ); // tricky
+
+		const positionB = _v3b.set( positionBX, positionBY, positionBZ );
+		const sphericalB = new THREE.Spherical().setFromVector3( positionB.sub( targetB ) );
 
 		const deltaTheta  = sphericalB.theta  - sphericalA.theta;
 		const deltaPhi    = sphericalB.phi    - sphericalA.phi;
 		const deltaRadius = sphericalB.radius - sphericalA.radius;
-		const deltaTarget = new THREE.Vector3().subVectors( _targetB, _targetA );
 
 		this._sphericalEnd.set(
 			sphericalA.radius + deltaRadius * x,
@@ -581,8 +594,6 @@ export default class CameraControls {
 			sphericalA.theta  + deltaTheta  * x
 		);
 
-		this._targetEnd.copy( _targetA ).add( deltaTarget.multiplyScalar( x ) );
-		
 		this._sanitizeSphericals();
 
 		if ( ! enableTransition ) {
@@ -596,15 +607,24 @@ export default class CameraControls {
 
 	}
 
-	setPosition( position, enableTransition ) {
+	setPosition( positionX, positionY, positionZ, enableTransition ) {
 
-		this.setLookAt( position, this._targetEnd, enableTransition );
+		this.setLookAt(
+			positionX, positionY, positionZ,
+			this._targetEnd.x, this._targetEnd.y, this._targetEnd.z,
+			enableTransition
+		);
 
 	}
 
-	setTarget( target, enableTransition ) {
+	setTarget( targetX, targetY, targetZ, enableTransition ) {
 
-		this.setLookAt( this.getPosition(), target, enableTransition );
+		const pos = this.getPosition( _v3a );
+		this.setLookAt(
+			pos.x, pos.y, pos.z,
+			targetX, targetY, targetZ,
+			enableTransition
+		);
 
 	}
 
@@ -636,7 +656,11 @@ export default class CameraControls {
 
 	reset( enableTransition ) {
 
-		this.setLookAt( this._position0, this._target0, enableTransition );
+		this.setLookAt(
+			this._position0.x, this._position0.y, this._position0.z,
+			this._target0.x, this._target0.y, this._target0.z,
+			enableTransition
+		);
 
 	}
 


### PR DESCRIPTION
Currently other API does not depend on THREE's root itself but `setLookAt` and `lerpLookAt` does.
It's no cool! (yes it's definitely my fault, sorry 😖 )

So I made it possible to receive JavaScript `Array` instead of `THREE.Vector3`.