### PR TITLE
Implement event dispatcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,15 @@ const cameraControls = new CameraControls( camera, renderer.domElement );
 - `.truckSpeed`: Default is `2.0`. speed of drag for truck and pedestal.
 - `.verticalDragToForward`: Default is `false`. same as `.screenSpacePanning` in three.js's OrbitControls.
 
+## Events
+
+Using `addEventListener( eventname, function )` you can subscribe to these events.
+
+- `controlstart`: Fired when the user starts to control the camera via mouse / touches.
+- `control`: Fired when the user controls the camera (dragging).
+- `controlend`: Fired when the user ends to control the camera.
+- `update`: Fired when camera position is updated.
+
 ## Methods
 
 #### `rotate( rotX, rotY, enableTransition )`
@@ -142,4 +151,4 @@ Reproduce the control state with JSON. `enableTransition` is where anim or not i
 
 #### `dispose()`
 
-Dispose cameraControls instancem, remove all eventListeners.
+Dispose the cameraControls instance itself, remove all eventListeners.

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -1,3 +1,5 @@
+import { EventDispatcher } from './event-dispatcher';
+
 let THREE;
 let _v3a;
 let _v3b;
@@ -14,7 +16,7 @@ const STATE = {
 	TOUCH_TRUCK :   5
 };
 
-export default class CameraControls {
+export default class CameraControls extends EventDispatcher {
 
 	static install( libs ) {
 
@@ -27,6 +29,8 @@ export default class CameraControls {
 	}
 
 	constructor( object, domElement ) {
+
+		super();
 
 		this.object = object;
 		this.enabled = true;
@@ -233,6 +237,14 @@ export default class CameraControls {
 				document.addEventListener( 'mouseup', endDragging );
 				document.addEventListener( 'touchend', endDragging );
 
+				scope.dispatchEvent( {
+					type: 'controlstart',
+					x,
+					y,
+					state,
+					originalEvent: event,
+				} );
+
 			}
 
 			function dragging( event ) {
@@ -319,6 +331,16 @@ export default class CameraControls {
 
 				}
 
+				scope.dispatchEvent( {
+					type: 'control',
+					x,
+					y,
+					deltaX,
+					deltaY,
+					state,
+					originalEvent: event,
+				} );
+
 			}
 
 			function endDragging() {
@@ -332,6 +354,12 @@ export default class CameraControls {
 				document.removeEventListener( 'touchmove', dragging );
 				document.removeEventListener( 'mouseup', endDragging );
 				document.removeEventListener( 'touchend', endDragging );
+
+				scope.dispatchEvent( {
+					type: 'controlend',
+					state,
+					originalEvent: event,
+				} );
 
 			}
 
@@ -715,6 +743,12 @@ export default class CameraControls {
 		this.object.lookAt( this._target );
 
 		const updated = this._needsUpdate;
+		if ( updated ) {
+			this.dispatchEvent( {
+				type: 'update'
+			} );
+		}
+
 		this._needsUpdate = false;
 
 		return updated;

--- a/src/event-dispatcher.js
+++ b/src/event-dispatcher.js
@@ -1,0 +1,92 @@
+/**
+ * This source code has been retrieved directly from Three.js repository.
+ * Three.js is also distributed under MIT license.
+ * https://github.com/mrdoob/three.js/blob/master/src/core/EventDispatcher.js
+ */
+
+/**
+ * https://github.com/mrdoob/eventdispatcher.js/
+ */
+
+function EventDispatcher() {}
+
+Object.assign( EventDispatcher.prototype, {
+
+	addEventListener: function ( type, listener ) {
+
+		if ( this._listeners === undefined ) this._listeners = {};
+
+		var listeners = this._listeners;
+
+		if ( listeners[ type ] === undefined ) {
+
+			listeners[ type ] = [];
+
+		}
+
+		if ( listeners[ type ].indexOf( listener ) === - 1 ) {
+
+			listeners[ type ].push( listener );
+
+		}
+
+	},
+
+	hasEventListener: function ( type, listener ) {
+
+		if ( this._listeners === undefined ) return false;
+
+		var listeners = this._listeners;
+
+		return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
+
+	},
+
+	removeEventListener: function ( type, listener ) {
+
+		if ( this._listeners === undefined ) return;
+
+		var listeners = this._listeners;
+		var listenerArray = listeners[ type ];
+
+		if ( listenerArray !== undefined ) {
+
+			var index = listenerArray.indexOf( listener );
+
+			if ( index !== - 1 ) {
+
+				listenerArray.splice( index, 1 );
+
+			}
+
+		}
+
+	},
+
+	dispatchEvent: function ( event ) {
+
+		if ( this._listeners === undefined ) return;
+
+		var listeners = this._listeners;
+		var listenerArray = listeners[ event.type ];
+
+		if ( listenerArray !== undefined ) {
+
+			event.target = this;
+
+			var array = listenerArray.slice( 0 );
+
+			for ( var i = 0, l = array.length; i < l; i ++ ) {
+
+				array[ i ].call( this, event );
+
+			}
+
+		}
+
+	}
+
+} );
+
+
+export { EventDispatcher };


### PR DESCRIPTION
See #18.

`CameraControls` now inherits [`EventDispatcher`](https://github.com/FMS-Cat/camera-controls/blob/537d6f5a3703efe8f7d128ea7e0156fa79b79f64/src/event-dispatcher.js)
(The source is completely same as https://github.com/mrdoob/three.js/blob/master/src/core/EventDispatcher.js)

We initially have these events:

- `controlstart`
  when `mousedown` or `touchstart` is occured

- `control`
  when `mousemove` or `touchmove` is occured

- `controlend`
  when `mouseup` or `touchend` is occured

- `update`
  When the camera is updated via controls or transition