### PR TITLE
Update controls (wheel, touchEvents and dampingFactor)

### DIFF
--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -34,7 +34,7 @@ export default class CameraControls extends EventDispatcher {
 
 		this.object = object;
 		this.enabled = true;
-		this.state = STATE.NONE;
+		this._state = STATE.NONE;
 
 		// How far you can dolly in and out ( PerspectiveCamera only )
 		this.minDistance = 0;
@@ -108,28 +108,28 @@ export default class CameraControls extends EventDispatcher {
 
 				event.preventDefault();
 
-				const prevState = scope.state;
+				const prevState = scope._state;
 
 				switch ( event.button ) {
 
 					case THREE.MOUSE.LEFT:
 
-						scope.state = STATE.ROTATE;
+						scope._state = STATE.ROTATE;
 						break;
 
 					case THREE.MOUSE.MIDDLE:
 
-						scope.state = STATE.DOLLY;
+						scope._state = STATE.DOLLY;
 						break;
 
 					case THREE.MOUSE.RIGHT:
 
-						scope.state = STATE.TRUCK;
+						scope._state = STATE.TRUCK;
 						break;
 
 				}
 
-				if ( prevState !== scope.state ) {
+				if ( prevState !== scope._state ) {
 
 					startDragging( event );
 
@@ -143,28 +143,28 @@ export default class CameraControls extends EventDispatcher {
 
 				event.preventDefault();
 
-				const prevState = scope.state;
+				const prevState = scope._state;
 
 				switch ( event.touches.length ) {
 
 					case 1:	// one-fingered touch: rotate
 
-						scope.state = STATE.TOUCH_ROTATE;
+						scope._state = STATE.TOUCH_ROTATE;
 						break;
 
 					case 2:	// two-fingered touch: dolly
 
-						scope.state = STATE.TOUCH_DOLLY;
+						scope._state = STATE.TOUCH_DOLLY;
 						break;
 
 					case 3: // three-fingered touch: truck
 
-						scope.state = STATE.TOUCH_TRUCK;
+						scope._state = STATE.TOUCH_TRUCK;
 						break;
 
 				}
 
-				if ( prevState !== scope.state ) {
+				if ( prevState !== scope._state ) {
 
 					startDragging( event );
 
@@ -224,13 +224,13 @@ export default class CameraControls extends EventDispatcher {
 				elementRect = scope.domElement.getBoundingClientRect();
 				dragStart.set( x, y );
 
-				// if ( scope.state === STATE.DOLLY ) {
+				// if ( scope._state === STATE.DOLLY ) {
 
 				// 	dollyStart.set( x, y );
 
 				// }
 
-				if ( scope.state === STATE.TOUCH_DOLLY ) {
+				if ( scope._state === STATE.TOUCH_DOLLY ) {
 
 					const dx = x - event.touches[ 1 ].pageX;
 					const dy = y - event.touches[ 1 ].pageY;
@@ -249,7 +249,7 @@ export default class CameraControls extends EventDispatcher {
 					type: 'controlstart',
 					x,
 					y,
-					state: scope.state,
+					state: scope._state,
 					originalEvent: event,
 				} );
 
@@ -270,7 +270,7 @@ export default class CameraControls extends EventDispatcher {
 
 				dragStart.set( x, y );
 
-				switch ( scope.state ) {
+				switch ( scope._state ) {
 
 					case STATE.ROTATE:
 					case STATE.TOUCH_ROTATE:
@@ -339,7 +339,7 @@ export default class CameraControls extends EventDispatcher {
 					y,
 					deltaX,
 					deltaY,
-					state: scope.state,
+					state: scope._state,
 					originalEvent: event,
 				} );
 
@@ -349,7 +349,7 @@ export default class CameraControls extends EventDispatcher {
 
 				if ( ! scope.enabled ) return;
 
-				scope.state = STATE.NONE;
+				scope._state = STATE.NONE;
 
 				document.removeEventListener( 'mousemove', dragging );
 				document.removeEventListener( 'touchmove', dragging );
@@ -358,7 +358,7 @@ export default class CameraControls extends EventDispatcher {
 
 				scope.dispatchEvent( {
 					type: 'controlend',
-					state: scope.state,
+					state: scope._state,
 					originalEvent: event,
 				} );
 
@@ -645,7 +645,7 @@ export default class CameraControls extends EventDispatcher {
 		const boundingRectAspect = width / height;
 		const fov = camera.fov * THREE.Math.DEG2RAD;
 		const aspect = camera.aspect;
-	
+
 		const heightToFit = boundingRectAspect < aspect ? height : width / aspect;
 		return heightToFit * 0.5 / Math.tan( fov * 0.5 ) + depth * 0.5;
 
@@ -690,7 +690,7 @@ export default class CameraControls extends EventDispatcher {
 		// var quatInverse = quat.clone().inverse();
 
 		const currentDampingFactor =
-			this.state === STATE.NONE ? this.dampingFactor : this.draggingDampingFactor;
+			this._state === STATE.NONE ? this.dampingFactor : this.draggingDampingFactor;
 		const lerpRatio = 1.0 - Math.exp( -currentDampingFactor * delta / 0.016 );
 
 		const deltaTheta  = this._sphericalEnd.theta  - this._spherical.theta;


### PR DESCRIPTION
一度にいろいろやっちゃってすいません。

---

## Improved wheel controls (primary purpose of this PR)

Currently we are dealing with wheel events (to perform dolly) without support of `event.wheelDelta` / `event.deltaY` ([this is completely same implementation as original OrbitControls](https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrbitControls.js#L524-L532)) .
This is making a mess under specific environments that wheel controls are ultrasmooth (e.g. single tick of wheel movement sustains for 50 or more frames).

Here is the reference of wheel control implementation in osgjs (Sketchfab engine), which uses `event.wheelDelta` / `event.deltaY` to achieve cross platform support (hardwares / OSes / browsers).
https://github.com/cedricpinson/osgjs/blob/00e5a7e9d9206c06fdde0436e1d62ab7cb5ce853/sources/osgViewer/input/source/InputSourceMouse.js#L89-L103
In this PR I followed this way, it will make its wheel navigation better in various environment.

https://github.com/FMS-Cat/camera-controls/blob/a8d3c42be027152984dbee767ca1b0b278514402/src/camera-controls.js#L176-L204

I replaced internal methods `dollyIn` and `dollyOut` with `dollyInternal` , it handles both dolly in and dolly out using delta value:

https://github.com/FMS-Cat/camera-controls/blob/a8d3c42be027152984dbee767ca1b0b278514402/src/camera-controls.js#L367-L383

## Improved touch dolly controls

I also implemented better support of touch controls, it will make dolly controls better also in touchscreen.
Current dolly controls in touchscreens goes pretty weird, since it seems not to be processing starting point of dolly controls ([here](https://github.com/yomotsu/camera-controls/compare/master...FMS-Cat:dev-better-wheel?expand=1#diff-365150a28bd0f13ace86934611892e9aL168)).
I also made dolly controls smoother using delta of pan in this PR, in the same way I did at wheel controls (using `dollyInternal()`).

## Better dampingFactor managing

When user starts to control the camera, currently we are storing `CameraControls.dampingFactor` to the local variable named `savedDampingFactor`, and replace it with `CameraControls.draggingDampingFactor`, until the control ends.
The replacing process occurs in internal method `startDragging` ([here](https://github.com/yomotsu/camera-controls/compare/master...FMS-Cat:dev-better-wheel?expand=1#diff-365150a28bd0f13ace86934611892e9aL232)) and `endDragging` ([here](https://github.com/yomotsu/camera-controls/compare/master...FMS-Cat:dev-better-wheel?expand=1#diff-365150a28bd0f13ace86934611892e9aL350)).
After I made changes to the code, `startDragging` might happen more than once before `endDragging` occurs.
So I made the internal variable `state` to global (`CameraControls.state`) and see if the `state` is `STATE.NONE` or not when it uses damping factor ([here](https://github.com/FMS-Cat/camera-controls/blob/a8d3c42be027152984dbee767ca1b0b278514402/src/camera-controls.js#L692-L693)).

---

えいごむずかしい
とりあえず、PC各ブラウザ・スマホでの動作確認、およびコードの変更箇所の命名などを確認いただければ幸いです。