### PR TITLE
DollyToCursor:  It's now not raycaster/object dependant

### DIFF
--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -796,7 +796,7 @@ export default class CameraControls extends EventDispatcher {
 				const worldToScreen = this._sphericalEnd.radius * Math.tan( this.object.fov / 360.0 * Math.PI );
 				const prevRadius = this._sphericalEnd.radius - this._dollyControlAmount;
 				const lerpRatio = ( prevRadius - this._sphericalEnd.radius ) / this._sphericalEnd.radius;
-				const cursor = this._targetEnd.clone()
+				const cursor = _v3A.copy( this._targetEnd )
 					.add( planeX.multiplyScalar( this._dollyControlCoord.x * worldToScreen * this.object.aspect ) )
 					.add( planeY.multiplyScalar( this._dollyControlCoord.y * worldToScreen ) );
 				this._targetEnd.lerp( cursor, lerpRatio );

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -28,6 +28,7 @@ export default class CameraControls extends EventDispatcher {
 		_v2 = new THREE.Vector2();
 		_v3A = new THREE.Vector3();
 		_v3B = new THREE.Vector3();
+		_v3C = new THREE.Vector3();
 		_xColumn = new THREE.Vector3();
 		_yColumn = new THREE.Vector3();
 		_sphericalA = new THREE.Spherical();

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -4,6 +4,7 @@ let THREE;
 let _v2;
 let _v3A;
 let _v3B;
+let _v3C;
 let _xColumn;
 let _yColumn;
 let _sphericalA;
@@ -790,8 +791,8 @@ export default class CameraControls extends EventDispatcher {
 			if ( this.object.isPerspectiveCamera ) {
 
 				const direction = _v3A.copy( _v3A.setFromSpherical( this._sphericalEnd ) ).normalize().negate();
-				const planeX = new THREE.Vector3().copy( direction ).cross( _v3B.set( 0.0, 1.0, 0.0 ) ).normalize();
-				const planeY = _v3B.crossVectors( planeX, direction );
+				const planeX = _v3B.copy( direction ).cross( _v3C.set( 0.0, 1.0, 0.0 ) ).normalize();
+				const planeY = _v3C.crossVectors( planeX, direction );
 				const worldToScreen = this._sphericalEnd.radius * Math.tan( this.object.fov / 360.0 * Math.PI );
 				const prevRadius = this._sphericalEnd.radius - this._dollyControlAmount;
 				const lerpRatio = ( prevRadius - this._sphericalEnd.radius ) / this._sphericalEnd.radius;


### PR DESCRIPTION
Previously, translation of `_target` occurs in `dollyToCursor` procedure via mouse wheel events could be happened more than once within a frame, especially under low frame rate conditions.
This PR will fix this problem, since `_target` translation operation is now in `update()` !