### PR TITLE
Add boundary feature

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -30,7 +30,7 @@ label{
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.dollyToCursor = this.checked">dolly to cursor</label>
 	<br>
-	<label><input type="checkbox" onchange="cameraControls.setBoundary( this.checked ? new THREE.Box3( new THREE.Vector3( -5.0, -5.0, -5.0 ), new THREE.Vector3( 5.0, 5.0, 5.0 ) ) : new THREE.Box3( new THREE.Vector3( - Infinity, - Infinity, - Infinity ), new THREE.Vector3( Infinity, Infinity, Infinity ) ) )">Enable a boundary box against target position</label>
+	<label><input type="checkbox" onchange="cameraControls.setBoundary( this.checked ? new THREE.Box3( new THREE.Vector3( -5.0, -5.0, -5.0 ), new THREE.Vector3( 5.0, 5.0, 5.0 ) ) : null )">Enable a boundary box against target position</label>
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.boundaryEnclosesCamera = this.checked">Enclose also the camera into the boundary</label>
 	<br>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -30,7 +30,7 @@ label{
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.dollyToCursor = this.checked">dolly to cursor</label>
 	<br>
-	<label><input type="checkbox" onchange="cameraControls.boundary = this.checked ? new THREE.Box3( new THREE.Vector3( -5.0, -5.0, -5.0 ), new THREE.Vector3( 5.0, 5.0, 5.0 ) ) : new THREE.Box3( new THREE.Vector3( - Infinity, - Infinity, - Infinity ), new THREE.Vector3( Infinity, Infinity, Infinity ) )">Enable a boundary box against target position</label>
+	<label><input type="checkbox" onchange="cameraControls.setBoundary( this.checked ? new THREE.Box3( new THREE.Vector3( -5.0, -5.0, -5.0 ), new THREE.Vector3( 5.0, 5.0, 5.0 ) ) : new THREE.Box3( new THREE.Vector3( - Infinity, - Infinity, - Infinity ), new THREE.Vector3( Infinity, Infinity, Infinity ) ) )">Enable a boundary box against target position</label>
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.boundaryEnclosesCamera = this.checked">Enclose also the camera into the boundary</label>
 	<br>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -30,6 +30,10 @@ label{
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.dollyToCursor = this.checked">dolly to cursor</label>
 	<br>
+	<label><input type="checkbox" onchange="cameraControls.boundary = this.checked ? new THREE.Box3( new THREE.Vector3( -5.0, -5.0, -5.0 ), new THREE.Vector3( 5.0, 5.0, 5.0 ) ) : new THREE.Box3( new THREE.Vector3( - Infinity, - Infinity, - Infinity ), new THREE.Vector3( Infinity, Infinity, Infinity ) )">Enable a boundary box against target position</label>
+	<br>
+	<label><input type="checkbox" onchange="cameraControls.boundaryEnclosesCamera = this.checked">Enclose also the camera into the boundary</label>
+	<br>
 	<button onclick="cameraControls.rotate(  45 * THREE.Math.DEG2RAD, 0, true )">rotate theta 45deg</button>
 	<button onclick="cameraControls.rotate( -90 * THREE.Math.DEG2RAD, 0, true )">rotate theta -90deg</button>
 	<button onclick="cameraControls.rotate( 360 * THREE.Math.DEG2RAD, 0, true )">rotate theta 360deg</button>

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,9 @@ If your camera is Y-up, `theta` will be the angle for y-axis rotation and `phi` 
 - `.maxPolarAngle`: Default is `Math.PI`, in radians.
 - `.minAzimuthAngle`: Default is `-Infinity`, in radians.
 - `.maxAzimuthAngle`: Default is `Infinity`, in radians.
+- `.boundary`: Default is `THREE.Box3` of from `-Infinity` to `Infinity`, encloses camera target into the boundary box.
+- `.boundaryFriction`: Default is `0.0`, friction ratio of the boundary.
+- `.boundaryEnclosesCamera`: Default is `false`, whether camera position should be enclosed in the boundary or not.
 - `.dampingFactor`: Default is `0.05`.
 - `.draggingDampingFactor`: Default is `0.25`.
 - `.phiSpeed`: Default is `1.0`. speed of phi rotation.

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,6 @@ If your camera is Y-up, `theta` will be the angle for y-axis rotation and `phi` 
 - `.maxPolarAngle`: Default is `Math.PI`, in radians.
 - `.minAzimuthAngle`: Default is `-Infinity`, in radians.
 - `.maxAzimuthAngle`: Default is `Infinity`, in radians.
-- `.boundary`: Default is `THREE.Box3` of from `-Infinity` to `Infinity`, encloses camera target into the boundary box.
 - `.boundaryFriction`: Default is `0.0`, friction ratio of the boundary.
 - `.boundaryEnclosesCamera`: Default is `false`, whether camera position should be enclosed in the boundary or not.
 - `.dampingFactor`: Default is `0.05`.
@@ -145,6 +144,10 @@ Similar to `setLookAt`, but it interpolates between two states.
 #### `setTarget( targetX, targetY, targetZ, enableTransition )`
 
 `setLookAt` without position, Stay still at the position.
+
+#### `setBoundary( box )`
+
+Set the boundary box that encloses the target of the camera.
 
 #### `getPosition( out )`
 

--- a/readme.md
+++ b/readme.md
@@ -145,9 +145,9 @@ Similar to `setLookAt`, but it interpolates between two states.
 
 `setLookAt` without position, Stay still at the position.
 
-#### `setBoundary( box )`
+#### `setBoundary( box3 )`
 
-Set the boundary box that encloses the target of the camera.
+Set the boundary box that encloses the target of the camera. `box3` is in `THREE.Box3`
 
 #### `getPosition( out )`
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -914,30 +914,30 @@ export default class CameraControls extends EventDispatcher {
 
 		 // See: https://twitter.com/FMS_Cat/status/1106508958640988161
 
-		const t1 = _v3B.copy( offset ).add( position ); // target
-		const tc = this.boundary.clampPoint( t1, _v3C ); // clamped target
-		const dtc = tc.sub( t1 ); // t1 -> tc
-		const dtcl = dtc.length(); // length of dtc
+		const newTarget = _v3B.copy( offset ).add( position ); // target
+		const clampedTarget = this.boundary.clampPoint( newTarget, _v3C ); // clamped target
+		const deltaClampedTarget = clampedTarget.sub( newTarget ); // newTarget -> clampedTarget
+		const deltaClampedTargetLength = deltaClampedTarget.length(); // length of deltaClampedTarget
 
-		if ( dtcl === 0.0 ) { // when the position doesn't have to be clamped
+		if ( deltaClampedTargetLength === 0.0 ) { // when the position doesn't have to be clamped
 
 			return position.add( offset );
 
-		} else if ( dtcl === offsetLength ) { // when the position is completely stuck
+		} else if ( deltaClampedTargetLength === offsetLength ) { // when the position is completely stuck
 
 			return position;
 
 		} else if ( friction === 0.0 ) {
 
-			return position.add( offset ).add( dtc );
+			return position.add( offset ).add( deltaClampedTarget );
 
 		} else {
 
-			const offsetFactor = 1.0 + friction * dtcl * dtcl / offset.dot( dtc );
+			const offsetFactor = 1.0 + friction * deltaClampedTargetLength * deltaClampedTargetLength / offset.dot( deltaClampedTarget );
 
 			return position
 				.add( _v3B.copy( offset ).multiplyScalar( offsetFactor ) )
-				.add( dtc.multiplyScalar( 1.0 - friction ) );
+				.add( deltaClampedTarget.multiplyScalar( 1.0 - friction ) );
 
 		}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -709,7 +709,10 @@ export default class CameraControls extends EventDispatcher {
 
 	setBoundary( box3 ) {
 
-		this._boundary.copy( box3 );
+		this._boundary.copy( box3 || new THREE.Box3(
+			new THREE.Vector3( - Infinity, - Infinity, - Infinity ),
+			new THREE.Vector3( Infinity, Infinity, Infinity )
+		) );
 		this._boundary.clampPoint( this._targetEnd, this._targetEnd );
 		this._hasUpdated = true;
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -927,7 +927,7 @@ export default class CameraControls extends EventDispatcher {
 		 // See: https://twitter.com/FMS_Cat/status/1106508958640988161
 
 		const newTarget = _v3B.copy( offset ).add( position ); // target
-		const clampedTarget = this.boundary.clampPoint( newTarget, _v3C ); // clamped target
+		const clampedTarget = this._boundary.clampPoint( newTarget, _v3C ); // clamped target
 		const deltaClampedTarget = clampedTarget.sub( newTarget ); // newTarget -> clampedTarget
 		const deltaClampedTargetLength2 = deltaClampedTarget.lengthSq(); // squared length of deltaClampedTarget
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -912,6 +912,8 @@ export default class CameraControls extends EventDispatcher {
 
 		}
 
+		 // See: https://twitter.com/FMS_Cat/status/1106508958640988161
+
 		const t1 = _v3B.copy( offset ).add( position ); // target
 		const tc = this.boundary.clampPoint( t1, _v3C ); // clamped target
 		const dtc = tc.sub( t1 ); // t1 -> tc
@@ -929,7 +931,7 @@ export default class CameraControls extends EventDispatcher {
 
 			return position.add( offset ).add( dtc );
 
-		} else { // https://twitter.com/FMS_Cat/status/1106508958640988161
+		} else {
 
 			const offsetFactor = 1.0 + friction * dtcl * dtcl / offset.dot( dtc );
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -59,10 +59,11 @@ export default class CameraControls extends EventDispatcher {
 
 		// Target cannot move outside of this box
 		this.boundary = new THREE.Box3(
-			new THREE.Vector3( - Infinity, - Infinity, - Infinity ),
-			new THREE.Vector3(   Infinity,   Infinity,   Infinity )
+			new THREE.Vector3( - 5.0, - 5.0, - 5.0 ),
+			new THREE.Vector3(   5.0,   5.0,   5.0 )
 		);
 		this.boundaryFriction = 0.0;
+		this.boundaryEnclosesCamera = true;
 
 		this.dampingFactor = 0.05;
 		this.draggingDampingFactor = 0.25;
@@ -811,6 +812,17 @@ export default class CameraControls extends EventDispatcher {
 		this._spherical.makeSafe();
 		this.object.position.setFromSpherical( this._spherical ).add( this._target );
 		this.object.lookAt( this._target );
+
+		if ( this.boundaryEnclosesCamera ) {
+
+			this._encloseToBoundary(
+				this.object.position.copy( this._target ),
+				_v3A.setFromSpherical( this._spherical ),
+				1.0
+			);
+
+		}
+
 
 		const updated = this._hasUpdated;
 		this._hasUpdated = false;

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -58,12 +58,9 @@ export default class CameraControls extends EventDispatcher {
 		this.maxAzimuthAngle = Infinity; // radians
 
 		// Target cannot move outside of this box
-		this.boundary = new THREE.Box3(
-			new THREE.Vector3( - 5.0, - 5.0, - 5.0 ),
-			new THREE.Vector3(   5.0,   5.0,   5.0 )
-		);
+		this.boundary = new THREE.Box3(); // -Infinity to Infinity by default
 		this.boundaryFriction = 0.0;
-		this.boundaryEnclosesCamera = true;
+		this.boundaryEnclosesCamera = false;
 
 		this.dampingFactor = 0.05;
 		this.draggingDampingFactor = 0.25;

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -904,9 +904,9 @@ export default class CameraControls extends EventDispatcher {
 
 	_encloseToBoundary( position, offset, friction ) {
 
-		const offsetLength = offset.length();
+		const offsetLength2 = offset.lengthSq();
 
-		if ( offsetLength === 0.0 ) { // sanity check
+		if ( offsetLength2 === 0.0 ) { // sanity check
 
 			return position;
 
@@ -917,13 +917,13 @@ export default class CameraControls extends EventDispatcher {
 		const newTarget = _v3B.copy( offset ).add( position ); // target
 		const clampedTarget = this.boundary.clampPoint( newTarget, _v3C ); // clamped target
 		const deltaClampedTarget = clampedTarget.sub( newTarget ); // newTarget -> clampedTarget
-		const deltaClampedTargetLength = deltaClampedTarget.length(); // length of deltaClampedTarget
+		const deltaClampedTargetLength2 = deltaClampedTarget.lengthSq(); // squared length of deltaClampedTarget
 
-		if ( deltaClampedTargetLength === 0.0 ) { // when the position doesn't have to be clamped
+		if ( deltaClampedTargetLength2 === 0.0 ) { // when the position doesn't have to be clamped
 
 			return position.add( offset );
 
-		} else if ( deltaClampedTargetLength === offsetLength ) { // when the position is completely stuck
+		} else if ( deltaClampedTargetLength2 === offsetLength2 ) { // when the position is completely stuck
 
 			return position;
 
@@ -933,7 +933,7 @@ export default class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const offsetFactor = 1.0 + friction * deltaClampedTargetLength * deltaClampedTargetLength / offset.dot( deltaClampedTarget );
+			const offsetFactor = 1.0 + friction * deltaClampedTargetLength2 / offset.dot( deltaClampedTarget );
 
 			return position
 				.add( _v3B.copy( offset ).multiplyScalar( offsetFactor ) )

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -58,7 +58,10 @@ export default class CameraControls extends EventDispatcher {
 		this.maxAzimuthAngle = Infinity; // radians
 
 		// Target cannot move outside of this box
-		this.boundary = new THREE.Box3(); // -Infinity to Infinity by default
+		this.boundary = new THREE.Box3(
+			new THREE.Vector3( - Infinity, - Infinity, - Infinity ),
+			new THREE.Vector3(   Infinity,   Infinity,   Infinity )
+		);
 		this.boundaryFriction = 0.0;
 		this.boundaryEnclosesCamera = false;
 

--- a/types/camera-controls.d.ts
+++ b/types/camera-controls.d.ts
@@ -25,7 +25,6 @@ export default class CameraControls extends EventDispatcher {
   public maxPolarAngle: number;
   public minAzimuthAngle: number;
   public maxAzimuthAngle: number;
-  public boundary: THREE.Box3;
   public boundaryFriction: number;
   public boundaryEnclosesCamera: boolean;
   public dampingFactor: number;
@@ -66,6 +65,7 @@ export default class CameraControls extends EventDispatcher {
   ): void;
   public setPosition( positionX: number, positionY: number, positionZ: number, enableTransition?: boolean ): void;
   public setTarget( targetX: number, targetY: number, targetZ: number, enableTransition?: boolean ): void;
+  public setBoundary( box3: THREE.Box3 ): void;
   public getDistanceToFit( width: number, height: number, depth: number ): number;
   public getTarget( out?: THREE.Vector3 ): THREE.Vector3;
   public getPosition( out?: THREE.Vector3 ): THREE.Vector3;
@@ -87,6 +87,7 @@ export default class CameraControls extends EventDispatcher {
 	protected _zoom0: number;
 	protected _dollyControlAmount: number;
 	protected _dollyControlCoord: THREE.Vector2;
+	protected _boundary: THREE.Box3;
 	protected _hasUpdated: boolean;
   
   // private methods

--- a/types/camera-controls.d.ts
+++ b/types/camera-controls.d.ts
@@ -25,6 +25,9 @@ export default class CameraControls extends EventDispatcher {
   public maxPolarAngle: number;
   public minAzimuthAngle: number;
   public maxAzimuthAngle: number;
+  public boundary: THREE.Box3;
+  public boundaryFriction: number;
+  public boundaryEnclosesCamera: boolean;
   public dampingFactor: number;
   public draggingDampingFactor: number;
   public phiSpeed: number;


### PR DESCRIPTION
An attempt to resolve #34

- New property: `.boundary`
  - Is a `THREE.Box3` encloses the camera target into a certain region
- New property: `.boundaryFriction`
  - Friction ratio of the boundary, can tweak boundaries behavior when the camera target is in collision
- New property: `.boundaryEnclosesCamera`
  - Whether camera position also should be enclosed in the boundary or not
- plus
  - Update `examples/basic.html`
  - Update README