### PR TITLE
Add viewport support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,31 @@ Return its current position.
 
 ---
 
+#### `setViewport( vector4? )`
+
+Set (or unset) the current viewport.
+
+Set this when you want to use renderer viewport and [`.dollyToCursor`](#properties) feature at the same time.
+
+See: [THREE.WebGLRenderer.setViewport()](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.setViewport)
+
+| Name      | Type             | Description |
+| --------- | ---------------- | ----------- |
+| `vector4` | `THREE.Vector4?` | Vector4 that represents the viewport, or `undefined` for unsetting this. |
+
+#### `setViewport( x, y, width, height )`
+
+Same as [`setViewport( vector4 )`](#setviewport-vector4-|-null-) , but you can give it four numbers that represents a viewport instead:
+
+| Name     | Type     | Description |
+| -------- | -------- | ----------- |
+| `x`      | `number` | Leftmost of the viewport. |
+| `y`      | `number` | Bottommost of the viewport. |
+| `width`  | `number` | Width of the viewport. |
+| `height` | `number` | Height of the viewport. |
+
+---
+
 #### `getPosition( out )`
 
 Return its current position.

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -761,7 +761,7 @@ export default class CameraControls extends EventDispatcher {
 
 	setViewport( viewportOrX, y, width, height ) {
 
-		if ( ! viewportOrX ) { // null
+		if ( viewportOrX === null ) { // null
 
 			this._viewport = null;
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -1044,7 +1044,7 @@ export default class CameraControls extends EventDispatcher {
 		if ( this._viewport ) {
 
 			target.x += this._viewport.x;
-			target.y += ( this._viewport.w - this._viewport.y );
+			target.y += rect.height - this._viewport.w - this._viewport.y;
 			target.z = this._viewport.z;
 			target.w = this._viewport.w;
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -81,10 +81,10 @@ export default class CameraControls extends EventDispatcher {
 		this.dollySpeed = 1.0;
 		this.truckSpeed = 2.0;
 		this.dollyToCursor = false;
-		this.viewport = null;
 		this.verticalDragToForward = false;
 
 		this._domElement = domElement;
+		this._viewport = null;
 
 		// the location of focus, where the object orbits around
 		this._target = new THREE.Vector3();
@@ -465,12 +465,12 @@ export default class CameraControls extends EventDispatcher {
 				target.x = rect.left;
 				target.y = rect.top;
 
-				if ( scope.viewport ) {
+				if ( scope._viewport ) {
 
-					target.x += scope.viewport.x;
-					target.y += ( scope.viewport.w - scope.viewport.y );
-					target.z = scope.viewport.z;
-					target.w = scope.viewport.w;
+					target.x += scope._viewport.x;
+					target.y += ( scope._viewport.w - scope._viewport.y );
+					target.z = scope._viewport.z;
+					target.w = scope._viewport.w;
 
 				} else {
 
@@ -784,6 +784,30 @@ export default class CameraControls extends EventDispatcher {
 		this._boundary.copy( box3 );
 		this._boundary.clampPoint( this._targetEnd, this._targetEnd );
 		this._hasUpdated = true;
+
+	}
+
+	setViewport( viewportOrX, y, width, height ) {
+
+		if ( ! viewportOrX ) { // null
+
+			this._viewport = null;
+
+			return;
+
+		}
+
+		this._viewport = this._viewport || new THREE.Vector4();
+
+		if ( typeof viewportOrX === 'number' ) { // number
+
+			this._viewport.set( viewportOrX, y, width, height );
+
+		} else { // Vector4
+
+			this._viewport.copy( viewportOrX );
+
+		}
 
 	}
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -259,7 +259,7 @@ export default class CameraControls extends EventDispatcher {
 
 				if ( scope.dollyToCursor ) {
 
-					elementRect = getClientRect( _v4 );
+					elementRect = scope._getClientRect( _v4 );
 					x = ( event.clientX - elementRect.x ) / elementRect.z *   2 - 1;
 					y = ( event.clientY - elementRect.y ) / elementRect.w * - 2 + 1;
 
@@ -285,7 +285,7 @@ export default class CameraControls extends EventDispatcher {
 
 				extractClientCoordFromEvent( event, _v2 );
 
-				elementRect = getClientRect( _v4 );
+				elementRect = scope._getClientRect( _v4 );
 				dragStart.copy( _v2 );
 
 				if ( scope._state === STATE.TOUCH_DOLLY_TRUCK ) {
@@ -452,34 +452,6 @@ export default class CameraControls extends EventDispatcher {
 					scope._hasUpdated = true;
 
 				}
-
-			}
-
-			/**
-			 * Get its client rect and package into given `THREE.Vector4` .
-			 */
-			function getClientRect( target ) {
-
-				const rect = scope._domElement.getBoundingClientRect();
-
-				target.x = rect.left;
-				target.y = rect.top;
-
-				if ( scope._viewport ) {
-
-					target.x += scope._viewport.x;
-					target.y += ( scope._viewport.w - scope._viewport.y );
-					target.z = scope._viewport.z;
-					target.w = scope._viewport.w;
-
-				} else {
-
-					target.z = rect.width;
-					target.w = rect.height;
-
-				}
-
-				return target;
 
 			}
 
@@ -1056,6 +1028,34 @@ export default class CameraControls extends EventDispatcher {
 		this._spherical.theta += PI_2 * Math.round(
 			( this._sphericalEnd.theta - this._spherical.theta ) / ( PI_2 )
 		);
+
+	}
+
+	/**
+	 * Get its client rect and package into given `THREE.Vector4` .
+	 */
+	_getClientRect( target ) {
+
+		const rect = this._domElement.getBoundingClientRect();
+
+		target.x = rect.left;
+		target.y = rect.top;
+
+		if ( this._viewport ) {
+
+			target.x += this._viewport.x;
+			target.y += ( this._viewport.w - this._viewport.y );
+			target.z = this._viewport.z;
+			target.w = this._viewport.w;
+
+		} else {
+
+			target.z = rect.width;
+			target.w = rect.height;
+
+		}
+
+		return target;
 
 	}
 

--- a/types/camera-controls.d.ts
+++ b/types/camera-controls.d.ts
@@ -91,7 +91,8 @@ export default class CameraControls extends EventDispatcher {
 	protected _dollyControlAmount: number;
 	protected _dollyControlCoord: THREE.Vector2;
 	protected _boundary: THREE.Box3;
-	protected _hasUpdated: boolean;
+  protected _viewport: THREE.Vector4;
+  protected _hasUpdated: boolean;
 
   // private methods
 	protected _removeAllEventListeners: () => void;

--- a/types/camera-controls.d.ts
+++ b/types/camera-controls.d.ts
@@ -65,6 +65,8 @@ export default class CameraControls extends EventDispatcher {
   public setPosition( positionX: number, positionY: number, positionZ: number, enableTransition?: boolean ): void;
   public setTarget( targetX: number, targetY: number, targetZ: number, enableTransition?: boolean ): void;
   public setBoundary( box3: THREE.Box3 ): void;
+  public setViewport( viewport: THREE.Vector4 | null ): void;
+  public setViewport( x: number, y: number, width: number, height: number ): void;
   public getDistanceToFit( width: number, height: number, depth: number ): number;
   public getTarget( out?: THREE.Vector3 ): THREE.Vector3;
   public getPosition( out?: THREE.Vector3 ): THREE.Vector3;
@@ -90,7 +92,7 @@ export default class CameraControls extends EventDispatcher {
 	protected _dollyControlCoord: THREE.Vector2;
 	protected _boundary: THREE.Box3;
 	protected _hasUpdated: boolean;
-  
+
   // private methods
 	protected _removeAllEventListeners: () => void;
   protected _sanitizeSphericals(): void;

--- a/types/camera-controls.d.ts
+++ b/types/camera-controls.d.ts
@@ -97,6 +97,11 @@ export default class CameraControls extends EventDispatcher {
   // private methods
 	protected _removeAllEventListeners: () => void;
   protected _sanitizeSphericals(): void;
+
+  /**
+   * Get its client rect and package into given `THREE.Vector4` .
+   */
+  protected _getClientRect( target: THREE.Vector4 ): THREE.Vector4;
 }
 
 export enum STATE {


### PR DESCRIPTION
Add viewport support for the CameraControls.

When you set viewport to your renderer, the `dollyToCursor` option does not work properly,
since it uses canvas' `getBoundingClientRect` .
The PR adds a new `.setViewport()` method to `CameraControls` .
The viewport is not required but if you set this
you can make the `dollyToCursor` works properly even if renderer's viewport is set.

### WIP

- [x] README
- [x] Type definitions