### PR TITLE
fix setLookAt from any camera.up

### DIFF
--- a/examples/camera-up.html
+++ b/examples/camera-up.html
@@ -54,12 +54,12 @@ const scene  = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera( 60, width / height, 0.01, 100 );
 
 camera.up.set( 0, 0, 1 );
-camera.position.set( 0, 5, 0 );
 const renderer = new THREE.WebGLRenderer( { antialias: true, stencil: false } );
 renderer.setSize( width, height );
 document.body.appendChild( renderer.domElement );
 
 const cameraControls = new CameraControls( camera, renderer.domElement );
+cameraControls.setLookAt( 0, 5, 0, 0, 0, 0, true );
 
 const mesh = new THREE.Mesh(
 	new THREE.BoxGeometry( 1, 1, 1 ),

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ const cameraControls = new CameraControls( camera, renderer.domElement );
 
 CameraControls uses Spherical Coordinates for orbit rotations.
 
-If your camera is Y-up, Azimuthal angle will be the angle for y-axis rotation and Polar angle will be the angle for vertiacal position.
+If your camera is Y-up, Azimuthal angle will be the angle for y-axis rotation and Polar angle will be the angle for vertical position.
 
 ![](https://yomotsu.github.io/camera-controls/examples/fig1.png)
 

--- a/src/camera-controls.js
+++ b/src/camera-controls.js
@@ -669,7 +669,7 @@ export default class CameraControls extends EventDispatcher {
 		const target = _v3B.set( targetX, targetY, targetZ );
 
 		this._targetEnd.copy( target );
-		this._sphericalEnd.setFromVector3( position.sub( target ) );
+		this._sphericalEnd.setFromVector3( position.sub( target ).applyQuaternion( this._yAxisUpSpace ) );
 		this._sanitizeSphericals();
 
 		if ( ! enableTransition ) {


### PR DESCRIPTION
Implementing the module in my project where I use `camera.up = (0, 0, 1)` I realized that the positioning of the camera in the `setLookAt` method was not modified accordingly to all the `sphericalEnd.setFromVector3` calls in the PR that implemented the utility of the camera controls for any camera.up vector, resulting, thus, in an erroneous position placement of the camera.

This behavior can be reproduced by eliminating line 57 from the `camera-up.html` example
```
camera.position.set( 0, 5, 0 );
```
and by adding the following at line 62 just after the definition of cameraControls
```
cameraControls.setLookAt( 0, 5, 0, 0, 0, 0, true );
```

This PR fixes this bug and updated the example to test the correct behavior.