### PR TITLE
Allow trackpad to truck on non-pinch gesture.

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -360,6 +360,10 @@ export class CameraControls extends EventDispatcher {
 
 				// Ref: https://stackoverflow.com/questions/15416851/catching-mac-trackpad-zoom/28685082#28685082
 				if ( isTrackpad && !event.ctrlKey ) {
+					// Note that this appears to not work in Edge for
+					// Microsoft Surface trackpads:
+					// https://developercommunity.visualstudio.com/content/problem/191727/two-point-touch-scrolling-in-code-viewer-doesnt-wo.html
+
 					// TODO: only need to fire this once
 					scope._getClientRect( elementRect );
 					truckInternal( event.deltaX, event.deltaY );

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -354,6 +354,18 @@ export class CameraControls extends EventDispatcher {
 
 				event.preventDefault();
 
+				// Ref: https://stackoverflow.com/questions/10744645/detect-touchpad-vs-mouse-in-javascript/56948026#56948026
+				// @ts-ignore
+				const isTrackpad = event.wheelDeltaY ? event.wheelDeltaY === -3 * event.deltaY : event.deltaMode === 0;
+
+				// Ref: https://stackoverflow.com/questions/15416851/catching-mac-trackpad-zoom/28685082#28685082
+				if ( isTrackpad && !event.ctrlKey ) {
+					// TODO: only need to fire this once
+					scope._getClientRect( elementRect );
+					truckInternal( event.deltaX, event.deltaY );
+					return;
+				}
+
 				// Ref: https://github.com/cedricpinson/osgjs/blob/00e5a7e9d9206c06fdde0436e1d62ab7cb5ce853/sources/osgViewer/input/source/InputSourceMouse.js#L89-L103
 				const deltaYFactor = isMac ? - 1 : - 3;
 


### PR DESCRIPTION
This is a PR to allow camera trucking for non-pinch trackpad gestures. I left comments but this relies on two tricks... the first is detection of a trackpad based on wheelDeltaX/Y (which typescript doesn't seem to like) here: https://stackoverflow.com/questions/10744645/detect-touchpad-vs-mouse-in-javascript/56948026#56948026

This may be only for Mac trackpads... please modify if there is something better...

The second trick is detecting pinch vs. non-pinch via `ctrlKey` as shown here: https://stackoverflow.com/questions/15416851/catching-mac-trackpad-zoom/28685082#28685082...

Also I would prefer to have this as an option but I didn't want to guess as to how you would like the API so I leave that to you.. maybe something as simple as `cameraControls.trackpad.emulateTruck`? I'm not sure.

Last it seems I need to call `scope._getClientRect` to make `truckInternal` work, however I am calling this many times, which shouldn't be necessary, but I didn't know the best way to hack a  `dragStart` event for a `wheel` event.  


