### PR TITLE
three should be in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "three": "^0.112.1",
     "typescript": "3.2.1"
   },
+  "peerDependencies": {
+    "three": "^0.112.1"
+  },
   "scripts": {
     "dev": "rollup --config --watch",
     "build": "rollup --config && terser dist/camera-controls.js -o dist/camera-controls.min.js --comments '/^!/'",


### PR DESCRIPTION
`three` should be in peerDependencies I think because:
- camera-controls has no use without three.js
- its type definitions depends on three