### PR TITLE
Update onMouseWheel listener

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -366,7 +366,7 @@ export class CameraControls extends EventDispatcher {
 
 			const onMouseWheel = ( event: WheelEvent ): void => {
 
-				if ( ! this.enabled ) return;
+				if ( ! this.enabled || this.mouseButtons.wheel === ACTION.NONE ) return;
 
 				event.preventDefault();
 


### PR DESCRIPTION
Hi,

I was trying to remove the listener on the wheel, because sometimes the canvas is just a part of the page. While it works well when ACTION.NONE is specified, it just blocks the scroll when you are on top of the canvas (because of the e.preventDefault). So before entering the function, we can just check if controls are enabled and if the user config is not NONE.
I'm not very familiar with TypeScript, I hope this change is acceptable.

Thank for your job by the way !