### PR TITLE
Updated readme.md to prompt the user to run CameraControls.install()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,17 @@ const cameraControls = new CameraControls( camera, renderer.domElement );
 } )();
 ```
 
+### Important!
+
+You *must install* Three.js before using camera-controls. Not doing so will lead to runtime errors (undefined references to THREE).
+
+**Before creating a new CameraControls instance, call**:
+```javascript
+CameraControls.install( { THREE: THREE } )
+```
+
+You can then proceed to use CameraControls.
+
 ## Constructor
 
 `CameraControls( camera, domElement )`


### PR DESCRIPTION
I ran into problems the first time I used camera-controls, because I didn't copy the example usage code, which contains the line `CameraControls.install( { THREE: THREE } )`. This is neccesary for camera-controls to work, but is not explicitly stated. I've added a warning to remind the user about the importance of running that line.