### PR TITLE
fitToBox() function with explicit theta and phi

### DIFF
--- a/dist/CameraControls.d.ts
+++ b/dist/CameraControls.d.ts
@@ -74,7 +74,7 @@ export declare class CameraControls extends EventDispatcher {
     truck(x: number, y: number, enableTransition?: boolean): void;
     forward(distance: number, enableTransition?: boolean): void;
     moveTo(x: number, y: number, z: number, enableTransition?: boolean): void;
-    fitToBox(box3OrObject: _THREE.Box3 | _THREE.Object3D, enableTransition: boolean, { paddingLeft, paddingRight, paddingBottom, paddingTop }?: Partial<FitToOptions>): void;
+    fitToBox(box3OrObject: _THREE.Box3 | _THREE.Object3D, enableTransition: boolean, { paddingLeft, paddingRight, paddingBottom, paddingTop, nearAxis, theta, phi }?: Partial<FitToOptions>): void;
     fitTo(box3OrObject: _THREE.Box3 | _THREE.Object3D, enableTransition: boolean, fitToOptions?: Partial<FitToOptions>): void;
     fitToSphere(sphereOrMesh: _THREE.Sphere | _THREE.Object3D, enableTransition: boolean): void;
     setLookAt(positionX: number, positionY: number, positionZ: number, targetX: number, targetY: number, targetZ: number, enableTransition?: boolean): void;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -35,6 +35,9 @@ export interface FitToOptions {
     paddingRight: number;
     paddingBottom: number;
     paddingTop: number;
+    nearAxis: boolean;
+    theta: number;
+    phi: number;
 }
 export interface CameraControlsEventMap {
     update: {

--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,9 @@ Fit the viewport to the box or the bounding box of the object, using the nearest
 | `options.paddingRight`  | `number`                     | Padding right. Default is `0` |
 | `options.paddingBottom` | `number`                     | Padding bottom. Default is `0` |
 | `options.paddingLeft`   | `number`                     | Padding left. Default is `0` |
+| `options.nearAxis`   | `boolean`                     | Whether to rotate to nearest axis. Default is `true` |
+| `options.theta`   | `number`                     | When nearAxis is false, rotate Azimuth angle to given theta. Default is 0 |
+| `options.phi`   | `number`                     | When nearAxis is false, rotate Polar angle to given phi. Default is 0 |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -311,9 +311,9 @@ Fit the viewport to the box or the bounding box of the object, using the nearest
 | `options.paddingRight`  | `number`                     | Padding right. Default is `0` |
 | `options.paddingBottom` | `number`                     | Padding bottom. Default is `0` |
 | `options.paddingLeft`   | `number`                     | Padding left. Default is `0` |
-| `options.nearAxis`   | `boolean`                     | Whether to rotate to nearest axis. Default is `true` |
-| `options.theta`   | `number`                     | When nearAxis is false, rotate Azimuth angle to given theta. Default is 0 |
-| `options.phi`   | `number`                     | When nearAxis is false, rotate Polar angle to given phi. Default is 0 |
+| `options.nearAxis`      | `boolean`                    | Whether to rotate to nearest axis. Default is `true` |
+| `options.theta`         | `number`                     | When nearAxis is false, rotate Azimuth angle to given theta. Default is 0 |
+| `options.phi`           | `number`                     | When nearAxis is false, rotate Polar angle to given phi. Default is 0 |
 
 ---
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -954,9 +954,11 @@ export class CameraControls extends EventDispatcher {
 		paddingLeft = 0,
 		paddingRight = 0,
 		paddingBottom = 0,
-		paddingTop = 0
+		paddingTop = 0,
+		nearAxis = true,
+		theta = 0,
+		phi = 0
 	}: Partial<FitToOptions> = {} ): void {
-
 		const aabb = ( box3OrObject as _THREE.Box3 ).isBox3
 			? _box3A.copy( box3OrObject as _THREE.Box3 )
 			: _box3A.setFromObject( box3OrObject as _THREE.Object3D );
@@ -968,11 +970,13 @@ export class CameraControls extends EventDispatcher {
 
 		}
 
-		// round to closest axis ( forward | backward | right | left | top | bottom )
-		const theta = roundToStep( this._sphericalEnd.theta, PI_HALF );
-		const phi   = roundToStep( this._sphericalEnd.phi,   PI_HALF );
-
+		if(nearAxis){
+			// round to closest axis ( forward | backward | right | left | top | bottom )
+			theta = roundToStep( this._sphericalEnd.theta, PI_HALF );
+			phi   = roundToStep( this._sphericalEnd.phi,   PI_HALF );
+		} 
 		this.rotateTo( theta, phi, enableTransition );
+
 
 		const normal = _v3A.setFromSpherical( this._sphericalEnd ).normalize();
 		const rotation = _quaternionA.setFromUnitVectors( normal, _AXIS_Z );

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,9 @@ export interface FitToOptions {
 	paddingRight : number;
 	paddingBottom: number;
 	paddingTop   : number;
+	nearAxis     : boolean;	
+	theta        : number;
+	phi          : number;
 }
 
 export interface CameraControlsEventMap {


### PR DESCRIPTION
Hello, thanks for the great open source.
I have been using camera-controls happily.

I have some use cases when FitToBox does not have to rotate to the nearest axis.
I thought explicit theta and phi are useful to prevent upside-down 3D models.

I have updated readme.

Thanks