### PR TITLE
Add Github Action for npm publishing

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,18 @@
+name: Publish to npm
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Setup .npmrc file to publish to npm
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Your GitHub Releases are out of sync with your npm version tag.
You could add a Github Action for publishing to npm on every Github Release,
as described in https://docs.github.com/en/actions/guides/publishing-nodejs-packages.

You just need to add your npm authentication token (`NODE_AUTH_TOKEN`) to your Github settings. 