### PR TITLE
fix: prevent warning on mobile devices

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -553,8 +553,10 @@ export class CameraControls extends EventDispatcher {
 			const dragging = ( event: Event ): void => {
 
 				if ( ! this._enabled ) return;
-
-				event.preventDefault();
+				
+				if (event.cancelable) {
+					event.preventDefault();
+				}
 
 				extractClientCoordFromEvent( event, _v2 );
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -554,9 +554,7 @@ export class CameraControls extends EventDispatcher {
 
 				if ( ! this._enabled ) return;
 				
-				if (event.cancelable) {
-					event.preventDefault();
-				}
+				if ( event.cancelable ) event.preventDefault();
 
 				extractClientCoordFromEvent( event, _v2 );
 


### PR DESCRIPTION
On mobile device i was seeing a lot of `Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted`.
This fixes it