### PR TITLE
Feat: make transitions thenable

### DIFF
--- a/examples/await-transitions.html
+++ b/examples/await-transitions.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>=^.^=</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<div class="info">
+	<p><a href="https://github.com/yomotsu/camera-controls">GitHub repo</a></p>
+	<button type="button" onclick="reset()">Reset</button>
+	<button type="button" onclick="transitionSequenceA()">Transition Sequence A</button>
+	<button type="button" onclick="transitionSequenceB()">Transition Sequence B</button>
+
+	<p>Transition promises will resolve when the camera slows to less than <code>controls.restThreshold</code> units in a single frame. You can set this value here</p> 	<label><input oninput="cameraControls.restThreshold = this.value" value="0.01" type="number" min="0.001" max="1" step="0.001"> Rest Threshold</label>
+
+</div>
+
+<script src="https://unpkg.com/three@0.118.3/build/three.min.js"></script>
+<script src="../dist/camera-controls.js"></script>
+<script>
+	const clock = new THREE.Clock();
+	let cameraControls, camera, scene, renderer, mesh;
+
+	const uiElems = document.querySelectorAll('button');
+	const enableUI = ( enabled ) => uiElems.forEach( elem => elem.disabled = !enabled );
+
+	function init() {
+
+		CameraControls.install( { THREE: THREE } );
+
+		const width  = window.innerWidth;
+		const height = window.innerHeight;
+
+		scene  = new THREE.Scene();
+		camera = new THREE.PerspectiveCamera( 60, width / height, 0.01, 100 );
+		camera.position.set( 0, 0, 5 );
+		renderer = new THREE.WebGLRenderer();
+		renderer.setSize( width, height );
+		document.body.appendChild( renderer.domElement );
+
+		cameraControls = new CameraControls( camera, renderer.domElement );
+
+		mesh = new THREE.Mesh(
+			new THREE.BoxBufferGeometry( 1, 1, 1 ),
+			new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
+		);
+		scene.add( mesh );
+
+		const gridHelper = new THREE.GridHelper( 50, 50 );
+		gridHelper.position.y = - 1;
+		scene.add( gridHelper );
+
+		renderer.render( scene, camera );
+
+	}
+
+	function animate() {
+
+		const delta = clock.getDelta();
+		const elapsed = clock.getElapsedTime();
+		const updated = cameraControls.update( delta );
+
+		// if ( elapsed > 30 ) { return; }
+
+		requestAnimationFrame( animate );
+
+		if ( updated ) {
+
+			renderer.render( scene, camera );
+
+		}
+	}
+
+	init();
+	animate();
+
+	cameraControls.addEventListener( 'transitionstart', () => {
+
+		console.log( 'transitionstart' );
+		enableUI( false );
+
+	} );
+
+	cameraControls.addEventListener( 'rest', () => {
+
+		console.log( 'rest' );
+
+	} );
+
+	cameraControls.addEventListener( 'controlend', () => {
+
+		console.log( 'controlend' );
+		enableUI( true );
+
+	} );
+
+	function randomRotate() {
+
+		return cameraControls.rotateTo( THREE.MathUtils.randFloat( 0, 2 * Math.PI ), THREE.MathUtils.randFloat( 0, Math.PI ), true );
+
+	}
+
+	function randomMove() {
+
+		return cameraControls.moveTo( THREE.MathUtils.randFloat( 0, 5 ), THREE.MathUtils.randFloat( 0, 5 ), THREE.MathUtils.randFloat( 0, 5 ), true );
+
+	}
+
+	function randomDolly() {
+
+		return cameraControls.dollyTo( THREE.MathUtils.randFloat( 0.5, 5 ), true );
+
+	}
+
+	function lookAt() {
+
+		return cameraControls.setLookAt(
+			THREE.MathUtils.randFloat( 0, 5 ), THREE.MathUtils.randFloat( 0, 5 ), THREE.MathUtils.randFloat( 0, 5 ),
+				0, 0, 0,
+				true,
+			);
+
+	}
+
+	async function transitionSequenceA() {
+
+		console.log("Starting sequence");
+
+		console.log("Performing rotation");
+		await randomRotate();
+
+		console.log("Performing move");
+		await randomMove();
+
+		console.log("Performing lookAt");
+		await lookAt();
+
+		console.log("Performing fitToBox");
+		await cameraControls.fitToBox( mesh, true, { paddingTop: 1, paddingLeft: 1, paddingBottom: 1, paddingRight: 1 } );
+
+		console.log("Sequence complete");
+		enableUI( true );
+
+	}
+
+	async function transitionSequenceB() {
+
+		console.log("Starting sequence");
+
+		console.log("Performing rotation and move");
+		await Promise.all([randomRotate(), randomMove()]);
+
+		console.log("Performing lookAt");
+		await lookAt();
+
+		console.log("Performing rotation");
+		await randomRotate();
+
+		console.log("Performing rotation and dolly");
+		Promise.all([randomRotate(), randomDolly()])
+
+		console.log("Performing fit");
+		await cameraControls.fitToSphere( mesh, true );
+
+		console.log("Sequence complete");
+		enableUI( true );
+
+	}
+
+	async function reset() {
+
+		console.log( "Resetting..." );
+		await cameraControls.reset( true );
+		console.log( "Reset complete" );
+		enableUI( true );
+
+	}
+
+
+
+
+</script>
+
+</body>
+</html>

--- a/examples/rest-and-sleep.html
+++ b/examples/rest-and-sleep.html
@@ -15,7 +15,7 @@
 	<p>These buttons will be disabled whenever a transition is occuring and then re-enabled when the transition is complete.</p>
 	<button id="restEventBtn">Enable on Rest</button><br>
 	<button id="sleepEventBtn">Enable on Sleep</button>
-	<p>The rest event will fire when the camera slows to less than <code>controls.restThreshold</code> units in a single frame. You can set this value here</p> 	<label><input oninput="cameraControls.restThreshold = this.value" value="0.0025" type="number" min="0.001" max="1" step="0.001"> Rest Epsilon</label>
+	<p>The rest event will fire when the camera slows to less than <code>controls.restThreshold</code> units in a single frame. You can set this value here</p> 	<label><input oninput="cameraControls.restThreshold = this.value" value="0.01" type="number" min="0.001" max="1" step="0.001"> Rest Threshold</label>
 
 	<p></p> The sleep event will fire once the camera completely stops. Due to damping, this is often long after it <em>appears</em> to have stopped.</p>
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ A camera control for three.js, similar to THREE.OrbitControls yet supports smoot
 - [camera shake effect](https://yomotsu.github.io/camera-controls/examples/effect-shake.html)
 - [rotate with duration and easing](https://yomotsu.github.io/camera-controls/examples/easing.html) (with [tween.js](https://github.com/tweenjs/tween.js))
 - [path animation](https://yomotsu.github.io/camera-controls/examples/path-animation.html) (with [tween.js](https://github.com/tweenjs/tween.js))
+- [complex transitions with `await`](https://yomotsu.github.io/camera-controls/examples/await-transitions.html)
 - [dragging outside the iframe](https://yomotsu.github.io/camera-controls/examples/iframe.html)
 
 ## Usage
@@ -597,6 +598,29 @@ Reproduce the control state with JSON. `enableTransition` is where anim or not i
 Dispose the cameraControls instance itself, remove all eventListeners.
 
 ---
+
+## Creating Complex Transitions
+
+All methods that take the `enableTransition` parameter return a `Promise` can be used to create complex animations, for example:
+
+``` js
+async function complexTransition() {
+	await cameraControls.rotateTo( Math.PI / 2, Math.PI / 4, true );
+	await cameraControls.dollyTo( 3, true );
+	await cameraControls.fitToSphere( mesh, true );
+}
+```
+
+This will rotate the camera, then dolly, and finally fit to the bounding sphere of the `mesh`. 
+
+The speed and timing of transitions can be tuned using `.restThreshold` and `.dampingFactor`.
+
+If `enableTransition` is `false`, the promise will resolve immediately:
+
+``` js
+// will resolve immediately
+await cameraControls.dollyTo( 3, false );
+```
 
 ## Breaking changes
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "declarationDir": "./dist",
     "target": "es5",
+    "lib": ["es2015", "dom"],
     "strict": true,
     "removeComments": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Building on #207 this makes transitions thenable, so you can now create complex camera animations using async/await:

``` js
async function complexTransition() {
        disableUI(true);
	await cameraControls.rotateTo( Math.PI / 2, Math.PI / 4, true );
	await cameraControls.dollyTo( 3, true );
	await cameraControls.fitToSphere( mesh, true );
	disableUI(false);
}
```

This will rotate the camera, then dolly, and finally fit to the bounding sphere of the `mesh`. It will also disable UI elements while the animation is playing. 

Create a new example `await-transitions` to show how it works. All methods that take the `enableTransitions` param are included. 

I also adjusted the default `restThreshold` to be 0.01 as this looks better to me after more testing. 