### PR TITLE
Add orbit point method fix #130

### DIFF
--- a/examples/focal-offset.html
+++ b/examples/focal-offset.html
@@ -19,6 +19,9 @@
 	<button onclick="cameraControls.setFocalOffset( 2, 2, 0, true )">setFocalOffset( 2, 2, 0 )</button>
 	<button onclick="cameraControls.setFocalOffset( 0, 0, 2, true )">setFocalOffset( 0, 0, 2 )</button>
 	<br>
+	<button onclick="cameraControls.setOrbitPoint( 2, 0, 0, true )">setOrbitPoint( 2, 0, 0 )</button>
+	<button onclick="cameraControls.setOrbitPoint( 0, 0, 0, true )">setOrbitPoint( 0, 0, 0 )</button>
+	<br>
 	<button onclick="cameraControls.rotate( 30 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta 30deg</button>
 	<br>
 	<button onclick="cameraControls.dolly(  1, true )">dolly  1</button>

--- a/readme.md
+++ b/readme.md
@@ -342,6 +342,18 @@ Set focal offset using the screen parallel coordinates.
 
 ---
 
+#### `setOrbitPoint( targetX, targetY, targetZ )`
+
+Set orbit point without moving the camera.
+
+| Name               | Type      | Description |
+| ------------------ | --------- | ----------- |
+| `targetX`                | `number`  | Orbit center position x |
+| `targetY`                | `number`  | Orbit center position y |
+| `targetZ`                | `number`  | Orbit center position z |
+
+---
+
 #### `forward( distance, enableTransition )`
 
 Move forward / backward.

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1566,6 +1566,25 @@ export class CameraControls extends EventDispatcher {
 
 	}
 
+	setOrbitPoint( targetX: number, targetY: number, targetZ : number ) {
+
+		_xColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 0 );
+		_yColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 1 );
+		_zColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 2 );
+
+		let cameraToPoint = new THREE.Vector3( targetX, targetY, targetZ ).sub( this._camera.position );
+		_xColumn.multiplyScalar( cameraToPoint.x );
+		_yColumn.multiplyScalar( cameraToPoint.y );
+		_zColumn.multiplyScalar( cameraToPoint.z );
+
+		_v3A.copy( _xColumn ).add( _yColumn ).add( _zColumn );
+		_v3A.z = _v3A.z + this.distance;
+
+		this.setFocalOffset( - _v3A.x, _v3A.y, - _v3A.z, false );
+		this.moveTo( targetX, targetY, targetZ, false );
+
+	}
+
 	setBoundary( box3: _THREE.Box3 ): void {
 
 		if ( ! box3 ) {


### PR DESCRIPTION
We find the solution to set orbit point without changing the camera position

```ts
setOrbitPoint( targetX: number, targetY: number, targetZ : number ) {
    _xColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 0 );
    _yColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 1 );
    _zColumn.setFromMatrixColumn( this._camera.matrixWorldInverse, 2 );

    let cameraToPoint = new THREE.Vector3( targetX, targetY, targetZ ).sub( this._camera.position );
    _xColumn.multiplyScalar( cameraToPoint.x );
    _yColumn.multiplyScalar( cameraToPoint.y );
    _zColumn.multiplyScalar( cameraToPoint.z );

    _v3A.copy( _xColumn ).add( _yColumn ).add( _zColumn );
    _v3A.z = _v3A.z + this.distance;

    this.setFocalOffset( - _v3A.x, _v3A.y, - _v3A.z, false );
    this.moveTo( targetX, targetY, targetZ, false );
}
```