### PR TITLE
Fix: TOUCH_DOLLY_OFFSET does not respect minDistance and maxDistance

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -724,7 +724,8 @@ export class CameraControls extends EventDispatcher {
 						const dollyY = this.dollyToCursor ? ( lastDragPosition.y - this._elementRect.y ) / this._elementRect.w * - 2 + 1 : 0;
 
 						this._state === ACTION.TOUCH_DOLLY ||
-						this._state === ACTION.TOUCH_DOLLY_TRUCK ?
+						this._state === ACTION.TOUCH_DOLLY_TRUCK ||
+						this._state === ACTION.TOUCH_DOLLY_OFFSET ?
 							this._dollyInternal( dollyDelta * TOUCH_DOLLY_FACTOR, dollyX, dollyY ) :
 							this._zoomInternal( dollyDelta * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
 


### PR DESCRIPTION
see https://github.com/yomotsu/camera-controls/issues/219