### PR TITLE
Set parameter to optional

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1575,7 +1575,7 @@ export class CameraControls extends EventDispatcher {
 	 * Set the boundary box that encloses the target of the camera. box3 is in THREE.Box3
 	 * @param box3
 	 */
-	setBoundary( box3: _THREE.Box3 ): void {
+	setBoundary( box3?: _THREE.Box3 ): void {
 
 		if ( ! box3 ) {
 


### PR DESCRIPTION
Calling `setBoundary()` without parameters causes _`Expected 1 arguments, but got 0.ts(2554)`_ error.

This PR simply makes the parameter optional – as [described in the doc](https://github.com/yomotsu/camera-controls#setboundary-box3-).