### PR TITLE
the rest event should watch deltaZoom in update()

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2259,12 +2259,12 @@ export class CameraControls extends EventDispatcher {
 		}
 
 		// zoom
-		const zoomDelta = this._zoomEnd - this._zoom;
-		this._zoom += zoomDelta * lerpRatio;
+		const deltaZoom = this._zoomEnd - this._zoom;
+		this._zoom += deltaZoom * lerpRatio;
 
 		if ( this._camera.zoom !== this._zoom ) {
 
-			if ( approxZero( zoomDelta ) ) this._zoom = this._zoomEnd;
+			if ( approxZero( deltaZoom ) ) this._zoom = this._zoomEnd;
 
 			this._camera.zoom = this._zoom;
 			this._camera.updateProjectionMatrix();
@@ -2296,6 +2296,7 @@ export class CameraControls extends EventDispatcher {
 				approxZero( deltaOffset.x, this.restThreshold ) &&
 				approxZero( deltaOffset.y, this.restThreshold ) &&
 				approxZero( deltaOffset.z, this.restThreshold ) &&
+				approxZero( deltaZoom, this.restThreshold ) &&
 				! this._hasRested
 			) {
 


### PR DESCRIPTION
see https://github.com/yomotsu/camera-controls/issues/270

`deltaZoom` is not watched in the condition for emitting `'rest'` event, then it causes #270.
This PR is to fix the problem.