### PR TITLE
fitToBox: adjust non Yup space

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1605,7 +1605,7 @@ export class CameraControls extends EventDispatcher {
 		promises.push( this.rotateTo( theta, phi, enableTransition ) );
 
 		const normal = _v3A.setFromSpherical( this._sphericalEnd ).normalize();
-		const rotation = _quaternionA.setFromUnitVectors( normal, _AXIS_Z );
+		const rotation = _quaternionA.setFromUnitVectors( normal, _AXIS_Z ).multiply( this._yAxisUpSpaceInverse );
 		const viewFromPolar = approxEquals( Math.abs( normal.y ), 1 );
 		if ( viewFromPolar ) {
 


### PR DESCRIPTION
see: https://github.com/yomotsu/camera-controls/issues/276

`fitToBox()` does not consider non Yup space. This PR is to fix the problem.