### PR TITLE
cover option in fitToBox

### DIFF
--- a/examples/fit-and-padding.html
+++ b/examples/fit-and-padding.html
@@ -13,6 +13,7 @@
 	<a href="https://github.com/yomotsu/camera-controls">GitHub repo</a><br>
 	<button onclick="rotateTo( 'front' ), cameraControls.reset( true )">reset</button><br>
 	<button onclick="rotateTo( 'front' ), cameraControls.fitToBox( mesh, true )">fit front side of the mesh</button><br>
+	<button onclick="rotateTo( 'front' ), cameraControls.fitToBox( mesh, true, { cover: true } )">fill (cover) front side of the mesh</button><br>
 	<button onclick="rotateTo( 'back' ), cameraControls.fitToBox( mesh, true, { paddingLeft: 0, paddingRight: 0, paddingBottom: 1, paddingTop: 2 } )">fit back side with padding(top: 2unit, bottom: 1unit )</button>
 	<button onclick="rotateTo( 'up' ), cameraControls.fitToBox( mesh, true, { paddingLeft: 0, paddingRight: 0, paddingBottom: 0.5, paddingTop: 2 } )">fit up side with padding(top: 2unit, bottom: 0.5unit )</button>
 	<button onclick="rotateTo( 'down' ), cameraControls.fitToBox( mesh, true, { paddingLeft: 4, paddingRight: 4, paddingBottom: 4, paddingTop: 4 } )">fit down side with padding(top: 4unit, bottom: 4unit, left: 4unit, right: 4unit )</button>

--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,6 @@ Working example: [user input config](https://yomotsu.github.io/camera-controls/e
 | --------------------- | -------- |
 | `mouseButtons.left`   | `CameraControls.ACTION.ROTATE`* \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 | `mouseButtons.right`  | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK`* \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
-| `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE`* |
 | `mouseButtons.wheel` ¹ | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 | `mouseButtons.middle` ² | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY`* \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 

--- a/readme.md
+++ b/readme.md
@@ -427,12 +427,14 @@ Move `target` position to given point.
 #### `fitToBox( box3OrMesh, enableTransition, { paddingTop, paddingLeft, paddingBottom, paddingRight } )`
 
 Fit the viewport to the box or the bounding box of the object, using the nearest axis. paddings are in unit.
+set `cover: true` to fill enter screen.
 
 | Name                    | Type                         | Description |
 | ----------------------- | ---------------------------- | ----------- |
 | `box3OrMesh`            | `THREE.Box3` \| `THREE.Mesh` | Axis aligned bounding box to fit the view. |
 | `enableTransition`      | `boolean`                    | Whether to move smoothly or immediately |
 | `options`               | `object`                     | Options |
+| `options.cover`         | `number`                     | Whether fill enter screen or not. Default is `false` |
 | `options.paddingTop`    | `number`                     | Padding top. Default is `0` |
 | `options.paddingRight`  | `number`                     | Padding right. Default is `0` |
 | `options.paddingBottom` | `number`                     | Padding bottom. Default is `0` |

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1582,6 +1582,7 @@ export class CameraControls extends EventDispatcher {
 	 * @category Methods
 	 */
 	fitToBox( box3OrObject: _THREE.Box3 | _THREE.Object3D, enableTransition: boolean, {
+		fill = false,
 		paddingLeft = 0,
 		paddingRight = 0,
 		paddingBottom = 0,
@@ -1662,7 +1663,7 @@ export class CameraControls extends EventDispatcher {
 
 		if ( isPerspectiveCamera( this._camera ) ) {
 
-			const distance = this.getDistanceToFitBox( bbSize.x, bbSize.y, bbSize.z );
+			const distance = this.getDistanceToFitBox( bbSize.x, bbSize.y, bbSize.z, fill );
 			promises.push( this.moveTo( center.x, center.y, center.z, enableTransition ) );
 			promises.push( this.dollyTo( distance, enableTransition ) );
 			promises.push( this.setFocalOffset( 0, 0, 0, enableTransition ) );
@@ -1672,7 +1673,7 @@ export class CameraControls extends EventDispatcher {
 			const camera = this._camera;
 			const width = camera.right - camera.left;
 			const height = camera.top - camera.bottom;
-			const zoom = Math.min( width / bbSize.x, height / bbSize.y );
+			const zoom = fill ? Math.max( width / bbSize.x, height / bbSize.y ) : Math.min( width / bbSize.x, height / bbSize.y );
 			promises.push( this.moveTo( center.x, center.y, center.z, enableTransition ) );
 			promises.push( this.zoomTo( zoom, enableTransition ) );
 			promises.push( this.setFocalOffset( 0, 0, 0, enableTransition ) );
@@ -1995,7 +1996,7 @@ export class CameraControls extends EventDispatcher {
 	 * @returns distance
 	 * @category Methods
 	 */
-	getDistanceToFitBox( width: number, height: number, depth: number ): number {
+	getDistanceToFitBox( width: number, height: number, depth: number, fillMode: boolean = false ): number {
 
 		if ( notSupportedInOrthographicCamera( this._camera, 'getDistanceToFitBox' ) ) return this._spherical.radius;
 
@@ -2003,7 +2004,7 @@ export class CameraControls extends EventDispatcher {
 		const fov = this._camera.getEffectiveFOV() * THREE.MathUtils.DEG2RAD;
 		const aspect = this._camera.aspect;
 
-		const heightToFit = boundingRectAspect < aspect ? height : width / aspect;
+		const heightToFit = ( fillMode ? boundingRectAspect > aspect : boundingRectAspect < aspect ) ? height : width / aspect;
 		return heightToFit * 0.5 / Math.tan( fov * 0.5 ) + depth * 0.5;
 
 	}

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1570,14 +1570,14 @@ export class CameraControls extends EventDispatcher {
 
 	/**
 	 * Fit the viewport to the box or the bounding box of the object, using the nearest axis. paddings are in unit.
-	 *
+	 * set `cover: true` to fill enter screen.
 	 * e.g.
 	 * ```
 	 * cameraControls.fitToBox( myMesh );
 	 * ```
 	 * @param box3OrObject Axis aligned bounding box to fit the view.
 	 * @param enableTransition Whether to move smoothly or immediately.
-	 * @param options | `<object>` { paddingTop: number, paddingLeft: number, paddingBottom: number, paddingRight: number }
+	 * @param options | `<object>` { cover: boolean, paddingTop: number, paddingLeft: number, paddingBottom: number, paddingRight: number }
 	 * @returns Transition end promise
 	 * @category Methods
 	 */

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -297,7 +297,6 @@ export class CameraControls extends EventDispatcher {
 	 * | --------------------- | -------- |
 	 * | `mouseButtons.left`   | `CameraControls.ACTION.ROTATE`* \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 	 * | `mouseButtons.right`  | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK`* \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
-	 * | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE`* |
 	 * | `mouseButtons.wheel` ¹ | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY` \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 	 * | `mouseButtons.middle` ² | `CameraControls.ACTION.ROTATE` \| `CameraControls.ACTION.TRUCK` \| `CameraControls.ACTION.OFFSET` \| `CameraControls.ACTION.DOLLY`* \| `CameraControls.ACTION.ZOOM` \| `CameraControls.ACTION.NONE` |
 	 *

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1582,7 +1582,7 @@ export class CameraControls extends EventDispatcher {
 	 * @category Methods
 	 */
 	fitToBox( box3OrObject: _THREE.Box3 | _THREE.Object3D, enableTransition: boolean, {
-		fill = false,
+		cover = false,
 		paddingLeft = 0,
 		paddingRight = 0,
 		paddingBottom = 0,
@@ -1663,7 +1663,7 @@ export class CameraControls extends EventDispatcher {
 
 		if ( isPerspectiveCamera( this._camera ) ) {
 
-			const distance = this.getDistanceToFitBox( bbSize.x, bbSize.y, bbSize.z, fill );
+			const distance = this.getDistanceToFitBox( bbSize.x, bbSize.y, bbSize.z, cover );
 			promises.push( this.moveTo( center.x, center.y, center.z, enableTransition ) );
 			promises.push( this.dollyTo( distance, enableTransition ) );
 			promises.push( this.setFocalOffset( 0, 0, 0, enableTransition ) );
@@ -1673,7 +1673,7 @@ export class CameraControls extends EventDispatcher {
 			const camera = this._camera;
 			const width = camera.right - camera.left;
 			const height = camera.top - camera.bottom;
-			const zoom = fill ? Math.max( width / bbSize.x, height / bbSize.y ) : Math.min( width / bbSize.x, height / bbSize.y );
+			const zoom = cover ? Math.max( width / bbSize.x, height / bbSize.y ) : Math.min( width / bbSize.x, height / bbSize.y );
 			promises.push( this.moveTo( center.x, center.y, center.z, enableTransition ) );
 			promises.push( this.zoomTo( zoom, enableTransition ) );
 			promises.push( this.setFocalOffset( 0, 0, 0, enableTransition ) );
@@ -1996,7 +1996,7 @@ export class CameraControls extends EventDispatcher {
 	 * @returns distance
 	 * @category Methods
 	 */
-	getDistanceToFitBox( width: number, height: number, depth: number, fillMode: boolean = false ): number {
+	getDistanceToFitBox( width: number, height: number, depth: number, cover: boolean = false ): number {
 
 		if ( notSupportedInOrthographicCamera( this._camera, 'getDistanceToFitBox' ) ) return this._spherical.radius;
 
@@ -2004,7 +2004,7 @@ export class CameraControls extends EventDispatcher {
 		const fov = this._camera.getEffectiveFOV() * THREE.MathUtils.DEG2RAD;
 		const aspect = this._camera.aspect;
 
-		const heightToFit = ( fillMode ? boundingRectAspect > aspect : boundingRectAspect < aspect ) ? height : width / aspect;
+		const heightToFit = ( cover ? boundingRectAspect > aspect : boundingRectAspect < aspect ) ? height : width / aspect;
 		return heightToFit * 0.5 / Math.tan( fov * 0.5 ) + depth * 0.5;
 
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export interface Touches {
 }
 
 export interface FitToOptions {
+	fill: boolean;
 	paddingLeft  : number;
 	paddingRight : number;
 	paddingBottom: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface Touches {
 }
 
 export interface FitToOptions {
-	fill: boolean;
+	cover: boolean;
 	paddingLeft  : number;
 	paddingRight : number;
 	paddingBottom: number;


### PR DESCRIPTION
see: https://github.com/yomotsu/camera-controls/issues/286

This PR is to add `cover` option in fitToBox(), to allow users to fill the entire screen with the target box.