### PR TITLE
fix fitToBox in non-Yup space

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1637,13 +1637,15 @@ export class CameraControls extends EventDispatcher {
 		promises.push( this.rotateTo( theta, phi, enableTransition ) );
 
 		const normal = _v3A.setFromSpherical( this._sphericalEnd ).normalize();
-		const rotation = _quaternionA.setFromUnitVectors( normal, _AXIS_Z ).multiply( this._yAxisUpSpaceInverse );
+		const rotation = _quaternionA.setFromUnitVectors( normal, _AXIS_Z );
 		const viewFromPolar = approxEquals( Math.abs( normal.y ), 1 );
 		if ( viewFromPolar ) {
 
 			rotation.multiply( _quaternionB.setFromAxisAngle( _AXIS_Y, theta ) );
 
 		}
+
+		rotation.multiply( this._yAxisUpSpaceInverse );
 
 		// make oriented bounding box
 		const bb = _box3B.makeEmpty();
@@ -1686,7 +1688,16 @@ export class CameraControls extends EventDispatcher {
 		bb.max.x += paddingRight;
 		bb.max.y += paddingTop;
 
-		rotation.setFromUnitVectors( _AXIS_Z, normal ).multiply( this._yAxisUpSpace );
+		rotation.setFromUnitVectors( _AXIS_Z, normal );
+
+		if ( viewFromPolar ) {
+
+			rotation.premultiply( _quaternionB.invert() );
+
+		}
+
+		rotation.premultiply( this._yAxisUpSpace );
+
 		const bbSize = bb.getSize( _v3A );
 		const center = bb.getCenter( _v3B ).applyQuaternion( rotation );
 


### PR DESCRIPTION
I found that fitToBox not working properly in non-Yup space. There is closed issue #276 about the same problem but in some circumstances it is still broken. This PR should fix two issues I found, and I believe make fitToBox work properly in every scenario in non-Yup space.

### Two problems I found

1. When one dimension of box is smaller than two others - fitting to most of the box sides is broken.
2. When fit from up or bottom - box is fitted always to the same size, despite changing azimuth angle by 90 deg.

### Reproduce first issue
1. open https://yomotsu.github.io/camera-controls/examples/camera-up.html
3. open console
2. run:

```
const box = new THREE.Box3(
  new THREE.Vector3(0, 0, 0),
  new THREE.Vector3(0.1, 0.5, 0.1),
);

scene.add(new THREE.Box3Helper(box));
cameraControls.rotateTo(Math.PI * 0.5, Math.PI * 0.5, true);
cameraControls.fitToBox(box, true);
```

### Reproduce second issue

Same as first issue but instead of two last lines run:

```cameraControls.rotateTo(Math.PI * 0.5, 0, true);cameraControls.fitToBox(box, true);```

And to see azimuth angle that is fitted properly:

```cameraControls.rotateTo(0, 0, true);cameraControls.fitToBox(box, true);```

