### PR TITLE
dollyToCursor should keep within boundaries

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2236,6 +2236,9 @@ export class CameraControls extends EventDispatcher {
 				this._targetEnd.lerp( cursor, lerpRatio );
 				this._target.copy( this._targetEnd );
 
+				// target position may be moved beyond boundary.
+				this._boundary.clampPoint( this._targetEnd, this._targetEnd );
+
 			} else if ( isOrthographicCamera( this._camera ) ) {
 
 				const camera = this._camera;


### PR DESCRIPTION
This PR is to fix https://github.com/yomotsu/camera-controls/issues/298

(sorry for the video quality, due to upload file size limitation)
<video src="https://user-images.githubusercontent.com/212837/186369918-9a973e19-18ea-4850-8c05-5534dbe0d1b9.mp4"></video>


