### PR TITLE
two finger rotate&zoom (TOUCH_DOLLY_ROTATE, TOUCH_ZOOM_ROTATE)

### DIFF
--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -35,3 +35,36 @@ export function maxNumberToInfinity( value: number ): number {
 	return value * Infinity;
 
 }
+
+export interface IVector2 {
+	x:number,
+	y:number
+}
+  
+export function getLen(v:IVector2): number{
+    return Math.sqrt(v.x * v.x + v.y * v.y);
+}
+
+export function dot(v1:IVector2, v2:IVector2): number {
+    return v1.x * v2.x + v1.y * v2.y;
+}
+
+export function getAngle(v1:IVector2, v2:IVector2): number {
+    const mr = getLen(v1) * getLen(v2);
+    if (mr === 0) return 0;
+    let r = dot(v1, v2) / mr;
+    if (r > 1) r = 1;
+    return Math.acos(r);
+}
+
+export function cross(v1:IVector2, v2:IVector2): number {
+    return v1.x * v2.y - v2.x * v1.y;
+}
+
+export function getRotateAngle(v1:IVector2, v2:IVector2): number {
+    let angle = getAngle(v1, v2);
+    if (cross(v1, v2) > 0) {
+        angle *= -1;
+    }
+    return angle * 180 / Math.PI;
+}


### PR DESCRIPTION
I'm using the camera-controls library just fine. Thank you.

I checked and used the option to change rotation and zoom with a two-finger touch. 
(recently merged options : TOUCH_DOLLY_ROTATE, TOUCH_ZOOM_ROTATE)
However, if I fix one finger and rotate it, it seems to work well, but I think it works strangely if I use both hands to move two fingers at the same time. 

So, I added the logic to get a vector of two fingers and rotate them. 
This logic works with TOUCH_DOLLY_ROTATE and TOUCH_ZOOM_ROTATE.

Please review. thank you.
