### PR TITLE
Fix check for dolly state when dragging

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -972,7 +972,7 @@ export class CameraControls extends EventDispatcher {
 
 					const dollyX = this.dollyToCursor ? ( dragStartPosition.x - this._elementRect.x ) / this._elementRect.width  *   2 - 1 : 0;
 					const dollyY = this.dollyToCursor ? ( dragStartPosition.y - this._elementRect.y ) / this._elementRect.height * - 2 + 1 : 0;
-					this._state === ACTION.DOLLY ?
+					( this._state & ACTION.DOLLY ) === ACTION.DOLLY ?
 						this._dollyInternal( deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY ) :
 						this._zoomInternal( deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
 


### PR DESCRIPTION
This PR fixes an issue where it would zoom instead of dolly if `this._state` had other flags set.
You can observe the current behavior [in the examples](https://yomotsu.github.io/camera-controls/examples/basic.html).
If you hold down the middle mouse button and also hold down the right mouse button at the same time, then drag, the camera will start to `zoom + truck` instead of `dollying + truck`.

Fixed by checking the flag instead of doing  `===` comparison.

I think the next if statement below might also have the same issue, but I don't have touch controls to test with.
