### PR TITLE
r3f `.connect` method

### DIFF
--- a/examples/r3f.html
+++ b/examples/r3f.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>=^.^=</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<div class="info">
+	<p><a href="https://github.com/yomotsu/camera-controls">GitHub repo</a></p>
+	<button onclick="cameraControls.connect( renderer.domElement )">connect</button>
+	<button onclick="cameraControls.dispose()">dispose</button>
+  <button onclick="cameraControls.rotate(  45 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta 45deg</button>
+</div>
+
+<script src="https://unpkg.com/three@0.146.0/build/three.min.js"></script>
+<script src="../dist/camera-controls.js"></script>
+<script>
+CameraControls.install( { THREE: THREE } );
+
+const width = window.innerWidth;
+const height = window.innerHeight;
+const clock = new THREE.Clock();
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera( 60, width / height, 0.01, 100 );
+camera.position.set( 0, 0, 5 );
+const renderer = new THREE.WebGLRenderer();
+globalThis.renderer = renderer;
+renderer.setSize( width, height );
+document.body.appendChild( renderer.domElement );
+
+const cameraControls = new CameraControls( camera );
+
+const mesh = new THREE.Mesh(
+	new THREE.BoxGeometry( 1, 1, 1 ),
+	new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
+);
+scene.add( mesh );
+
+const gridHelper = new THREE.GridHelper( 50, 50 );
+gridHelper.position.y = - 1;
+scene.add( gridHelper );
+
+renderer.render( scene, camera );
+
+( function anim () {
+
+	const delta = clock.getDelta();
+	const elapsed = clock.getElapsedTime();
+	const updated = cameraControls.update( delta );
+
+	// if ( elapsed > 30 ) { return; }
+
+	requestAnimationFrame( anim );
+
+	if ( updated ) {
+
+		renderer.render( scene, camera );
+		console.log( 'rendered' );
+
+	}
+
+} )();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Introducing a `.connect` method to allow binding events and side-effects independently from the instanciation:

```ts
const cameraControls = new CameraControls(camera)

cameraControls.connect(renderer.domElement)
cameraControls.dispose()
cameraControls.connect(renderer.domElement)
cameraControls.dispose()
```

Backward compatible:

```ts
const cameraControls = new CameraControls(camera, renderer.domElement) // auto-`connect`ed
```

This is useful in order [`<CameraControls>` drei component](https://github.com/pmndrs/drei#controls) to work properly with r3f.

See: https://github.com/yomotsu/camera-controls/issues/262#issuecomment-1399431569