### PR TITLE
missing `EventDispatcher`.`hasEventListener` method

### DIFF
--- a/src/EventDispatcher.ts
+++ b/src/EventDispatcher.ts
@@ -25,13 +25,19 @@ export class EventDispatcher {
 
 	}
 
-	// hasEventListener( type: string, listener: Listener ): boolean {
+	/**
+	 * Presence of the specified event listener.
+	 * @param type event name
+	 * @param listener handler function
+	 * @category Methods
+	 */
+	hasEventListener( type: string, listener: Listener ): boolean {
 
-	// 	const listeners = this._listeners;
+		const listeners = this._listeners;
 
-	// 	return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
+		return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
 
-	// }
+	}
 
 	/**
 	 * Removes the specified event listener


### PR DESCRIPTION
I got the following TS error, while adding a new `makeDefault` prop for the drei component in https://github.com/pmndrs/drei/pull/1247:

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/76580/214712595-3d7381aa-e0c6-428b-a517-01a87bc3c2b0.png">

The `EventDispatcher.hasEventListener` was commented, I'm not sure why... I tried uncommented it and check the tests were still ok.

I let you confirm @yomotsu 
