### PR TITLE
Exposing `CameraControls.createBoundingSphere`

### DIFF
--- a/examples/fit-to-bounding-sphere.html
+++ b/examples/fit-to-bounding-sphere.html
@@ -64,7 +64,7 @@ scene.add( gridHelper );
 
 new GLTFLoader().load( './rubber-duck.glb', function ( gltf ) {
 
-	const boundingSphere = computeBoundingSphere( gltf.scene );
+	const boundingSphere = CameraControls.createBoundingSphere( gltf.scene );
 	const sphereHelper = new THREE.Mesh(
 		new THREE.SphereBufferGeometry( boundingSphere.radius, 16, 16 ),
 		new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
@@ -104,47 +104,6 @@ renderer.render( scene, camera );
 	}
 
 } )();
-
-const _box = new THREE.Box3();
-const _vec3 = new THREE.Vector3();
-function computeBoundingSphere( object3d ) {
-
-	// var meshCount = 0;
-	const points = [];
-	const boundingSphere = new THREE.Sphere();
-	const center = boundingSphere.center;
-
-	// find the center
-	object3d.traverse( function( object ) {
-
-		if ( ! object.isMesh ) return;
-
-		_box.expandByObject( object );
-
-	} );
-	_box.getCenter( center );
-
-	// find the radius
-	var maxRadiusSq = 0;
-	object3d.traverse( function( object ) {
-
-		if ( ! object.isMesh ) return;
-
-		const position = object.geometry.attributes.position;
-
-		for ( var i = 0, l = position.count; i < l; i ++ ) {
-
-			_vec3.fromBufferAttribute( position, i );
-			maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vec3 ) );
-
-		}
-
-	} );
-
-	boundingSphere.radius = Math.sqrt( maxRadiusSq );
-	return boundingSphere;
-
-}
 </script>
 
 </body>


### PR DESCRIPTION
# What

I found that it could be useful to borrow the inner `createBoundingSphere` function.
Starting with the `examples/fit-to-bounding-sphere.html` which was needing it and has to redefined it.

=> I've just made this inner function a static method, and make `examples/fit-to-bounding-sphere.html` using it :)

# Why

Let me give you some context...

In my project, for debug purposes, I wanted to show the bounding sphere of `myMesh` (like in the `fit-to-bounding-sphere`). Primarily, I've created my own BS from `myMesh` but I figured out it was a little bigger that the one CC internally relies on to fitTo...

