### PR TITLE
fix(examples/fitToSphere): reset button

### DIFF
--- a/examples/fit-to-bounding-sphere.html
+++ b/examples/fit-to-bounding-sphere.html
@@ -46,6 +46,7 @@ renderer.outputEncoding = THREE.sRGBEncoding;
 document.body.appendChild( renderer.domElement );
 
 const cameraControls = new CameraControls( camera, renderer.domElement );
+globalThis.cameraControls = cameraControls;
 
 new THREE.TextureLoader().load( './env.jpg', ( equirectangularMap ) => {
 


### PR DESCRIPTION
`reset` button was currently broken due to `cameraControls` var is not global due to `<script type="module">`

This PR just fix this.