### PR TITLE
Do not prevent `.enabled = ` before being `.connect()`ed

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1174,9 +1174,9 @@ export class CameraControls extends EventDispatcher {
 
 	set enabled( enabled: boolean ) {
 
-		if ( ! this._domElement ) return;
-
 		this._enabled = enabled;
+
+		if ( ! this._domElement ) return;
 		if ( enabled ) {
 
 			this._domElement.style.touchAction = 'none';


### PR DESCRIPTION
When using drei `<CameraControls enabled={false} />`, the CC instance is not immediately connected `new CameraControls(camera)`, but `.enabled = false` still happens.

https://github.com/yomotsu/camera-controls/blob/9f7b74398fe3fb7f4eba9b9de8cdcb915e8530ae/src/CameraControls.ts#L1177-L1179
was preventing the value to be set.

A minimal example with drei component, demoing the issue:
https://codesandbox.io/s/cameracontrols-basic-forked-b6qbfg?file=/src/App.js