### PR TITLE
dispose zombie pointer

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -508,12 +508,26 @@ export class CameraControls extends EventDispatcher {
 			// to keep receiving pointermove evens outside dragging iframe
 			// https://taye.me/blog/tips/2015/11/16/mouse-drag-outside-iframe/
 
+			const mouseButton =
+				( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.LEFT :
+				( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ? MOUSE_BUTTON.MIDDLE :
+				( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ? MOUSE_BUTTON.RIGHT :
+				null;
+
+			if ( mouseButton !== null ) {
+
+				const zombiePointer = this._findPointerByMouseButton( mouseButton );
+				zombiePointer && this._activePointers.splice( this._activePointers.indexOf( zombiePointer ), 1 );
+
+			}
+
 			const pointer = {
 				pointerId: event.pointerId,
 				clientX: event.clientX,
 				clientY: event.clientY,
 				deltaX: 0,
 				deltaY: 0,
+				mouseButton,
 			};
 			this._activePointers.push( pointer );
 
@@ -532,12 +546,30 @@ export class CameraControls extends EventDispatcher {
 
 			if ( ! this._enabled || ! this._domElement ) return;
 
+			const mouseButton =
+				( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.LEFT :
+				( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ? MOUSE_BUTTON.MIDDLE :
+				( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ? MOUSE_BUTTON.RIGHT :
+				null;
+
+			if ( mouseButton !== null ) {
+
+				const zombiePointer = this._findPointerByMouseButton( mouseButton );
+				zombiePointer && this._activePointers.splice( this._activePointers.indexOf( zombiePointer ), 1 );
+
+			}
+
 			const pointer = {
 				pointerId: 0,
 				clientX: event.clientX,
 				clientY: event.clientY,
 				deltaX: 0,
 				deltaY: 0,
+				mouseButton:
+					( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.LEFT :
+					( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.MIDDLE :
+					( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.RIGHT :
+					null,
 			};
 			this._activePointers.push( pointer );
 
@@ -2635,6 +2667,12 @@ export class CameraControls extends EventDispatcher {
 	protected _findPointerById( pointerId: number ): PointerInput | undefined {
 
 		return this._activePointers.find( ( activePointer ) => activePointer.pointerId === pointerId );
+
+	}
+
+	protected _findPointerByMouseButton( mouseButton: MOUSE_BUTTON ): PointerInput | undefined {
+
+		return this._activePointers.find( ( activePointer ) => activePointer.mouseButton === mouseButton );
 
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export const MOUSE_BUTTON = {
 	LEFT: 1,
 	RIGHT: 2,
 	MIDDLE: 4,
-};
+} as const;
+export type MOUSE_BUTTON = typeof MOUSE_BUTTON[ keyof typeof MOUSE_BUTTON ];
 
 export const ACTION = Object.freeze( {
 	NONE: 0,
@@ -54,6 +55,7 @@ export interface PointerInput {
 	clientY: number;
 	deltaX: number;
 	deltaY: number;
+	mouseButton: MOUSE_BUTTON | null;
 }
 
 type mouseButtonAction = typeof ACTION.ROTATE | typeof ACTION.TRUCK | typeof ACTION.OFFSET | typeof ACTION.DOLLY | typeof ACTION.ZOOM | typeof ACTION.NONE;


### PR DESCRIPTION
see https://github.com/yomotsu/camera-controls/issues/372

if right/middle drag ends outside of window, it can't be detected by JS (AFAIK).
Check for zombie pointers that were not detected in the previous drag, on drag start, and discard them.