### PR TITLE
`master` as release-branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build and Release to npm
 on:
   push:
     branches:
-      - 'dev'
+      - 'master'
 
 # Cancel any previous run (see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)
 concurrency:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,3 +1,3 @@
 {
-  "branches": ["dev"]
+  "branches": ["master"]
 }


### PR DESCRIPTION
In order to trigger a release when pushing on `master` (rather than `dev`) as discussed in https://github.com/yomotsu/camera-controls/pull/365

---

don't miss out to:
- [x] add the `master` branch in [Settings > Environments](https://github.com/yomotsu/camera-controls/settings/environments) > github pages

All the rest should be good if I don't forget anything...

NB: maybe if one day, merge-queue becomes available for personal repos, we could go back to `dev` ;)