### PR TITLE
Add PointerLock API compatibility

### DIFF
--- a/examples/pointer-lock.html
+++ b/examples/pointer-lock.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>=^.^=</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<div class="info">
+	<p><a href="https://github.com/yomotsu/camera-controls">GitHub repo</a></p>
+	<button onclick="void lockCursor()">lock pointer</button>
+</div>
+
+<script src="https://unpkg.com/three@0.149.0/build/three.min.js"></script>
+<script src="../dist/camera-controls.js"></script>
+<script>
+CameraControls.install( { THREE: THREE } );
+
+const width = window.innerWidth;
+const height = window.innerHeight;
+const clock = new THREE.Clock();
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera( 60, width / height, 0.01, 100 );
+camera.position.set( 0, 0, 5 );
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize( width, height );
+document.body.appendChild( renderer.domElement );
+
+const cameraControls = new CameraControls( camera, renderer.domElement );
+
+const mesh = new THREE.Mesh(
+	new THREE.BoxGeometry( 1, 1, 1 ),
+	new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
+);
+scene.add( mesh );
+
+const gridHelper = new THREE.GridHelper( 50, 50 );
+gridHelper.position.y = - 1;
+scene.add( gridHelper );
+
+renderer.render( scene, camera );
+
+function lockCursor () {
+	renderer.domElement.requestPointerLock();
+}
+
+( function anim () {
+
+	const delta = clock.getDelta();
+	const elapsed = clock.getElapsedTime();
+	const updated = cameraControls.update( delta );
+
+	requestAnimationFrame( anim );
+
+	if ( updated ) {
+
+		renderer.render( scene, camera );
+		console.log( 'rendered' );
+
+	}
+
+} )();
+</script>
+
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ A camera control for three.js, similar to THREE.OrbitControls yet supports smoot
 - [collision](https://yomotsu.github.io/camera-controls/examples/collision.html)
 - [first-person](https://yomotsu.github.io/camera-controls/examples/first-person.html)
 - [third-person](https://yomotsu.github.io/meshwalk/example/5_terrain.html) (with [meshwalk](https://github.com/yomotsu/meshwalk))
+- [pointer lock](https://yomotsu.github.io/camera-controls/examples/pointer-lock.html)
 - [auto rotate](https://yomotsu.github.io/camera-controls/examples/auto-rotate.html)
 - [camera shake effect](https://yomotsu.github.io/camera-controls/examples/effect-shake.html)
 - [rotate with time duration and easing](https://yomotsu.github.io/camera-controls/examples/easing.html) (with [gsap](https://www.npmjs.com/package/gsap))

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -500,6 +500,21 @@ export class CameraControls extends EventDispatcher {
 		const lastDragPosition = new THREE.Vector2() as _THREE.Vector2;
 		const dollyStart = new THREE.Vector2() as _THREE.Vector2;
 
+		const disposePointer = ( pointer?: PointerInput ) => {
+
+			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
+
+			if ( ! pointer || isPointerLockActive && this._activePointers.length <= 1 ) {
+
+				// NOTE Do not dispose pointer-locked pointer
+				return;
+
+			}
+
+			this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
+
+		};
+
 		const onPointerDown = ( event: PointerEvent ) => {
 
 			if ( ! this._enabled || ! this._domElement ) return;
@@ -516,8 +531,7 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				const zombiePointer = this._findPointerByMouseButton( mouseButton );
-				zombiePointer && this._activePointers.splice( this._activePointers.indexOf( zombiePointer ), 1 );
+				disposePointer( this._findPointerByMouseButton( mouseButton ) );
 
 			}
 
@@ -554,8 +568,7 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				const zombiePointer = this._findPointerByMouseButton( mouseButton );
-				zombiePointer && this._activePointers.splice( this._activePointers.indexOf( zombiePointer ), 1 );
+				disposePointer( this._findPointerByMouseButton( mouseButton ) );
 
 			}
 
@@ -685,15 +698,7 @@ export class CameraControls extends EventDispatcher {
 
 		const onPointerUp = ( event: PointerEvent ) => {
 
-			const pointerId = event.pointerId;
-			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
-
-			if ( ! isPointerLockActive || ( isPointerLockActive && this._activePointers.length > 1 ) ) {
-
-				const pointer = this._findPointerById( pointerId );
-				pointer && this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
-
-			}
+			disposePointer( this._findPointerById( event.pointerId ) );
 
 			if ( event.pointerType === 'touch' ) {
 
@@ -733,8 +738,7 @@ export class CameraControls extends EventDispatcher {
 
 		const onMouseUp = () => {
 
-			const pointer = this._findPointerById( 0 );
-			pointer && this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
+			disposePointer( this._findPointerById( 0 ) );
 			this._state = ACTION.NONE;
 
 			endDragging();
@@ -830,8 +834,7 @@ export class CameraControls extends EventDispatcher {
 					event instanceof MouseEvent ? 0 :
 					0;
 
-				const pointer = this._findPointerById( pointerId );
-				pointer && this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
+				disposePointer( this._findPointerById( pointerId ) );
 
 				// eslint-disable-next-line no-undef
 				this._domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, { passive: false } as AddEventListenerOptions );

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -686,8 +686,14 @@ export class CameraControls extends EventDispatcher {
 		const onPointerUp = ( event: PointerEvent ) => {
 
 			const pointerId = event.pointerId;
-			const pointer = this._findPointerById( pointerId );
-			pointer && this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
+			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
+
+			if ( ! isPointerLockActive || ( isPointerLockActive && this._activePointers.length > 1 ) ) {
+
+				const pointer = this._findPointerById( pointerId );
+				pointer && this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
+
+			}
 
 			if ( event.pointerType === 'touch' ) {
 
@@ -1126,6 +1132,8 @@ export class CameraControls extends EventDispatcher {
 
 			if ( ! this._enabled || ! this._domElement ) return;
 
+			this.cancel();
+
 			// Element.requestPointerLock is allowed to happen without any pointer active - create a faux one for compatibility with controls
 			const pointer: PointerInput = {
 				pointerId: 1,
@@ -1149,7 +1157,7 @@ export class CameraControls extends EventDispatcher {
 
 		const unlockPointer = (): void => {
 
-			this._activePointers = [];
+			this.cancel();
 
 		};
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -500,11 +500,11 @@ export class CameraControls extends EventDispatcher {
 		const lastDragPosition = new THREE.Vector2() as _THREE.Vector2;
 		const dollyStart = new THREE.Vector2() as _THREE.Vector2;
 
-		const disposePointer = ( pointer?: PointerInput ) => {
+		const disposePointer = ( pointer: PointerInput ) => {
 
 			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
 
-			if ( ! pointer || isPointerLockActive && this._activePointers.length <= 1 ) {
+			if ( isPointerLockActive && this._activePointers.length <= 1 ) {
 
 				// NOTE Do not dispose pointer-locked pointer
 				return;
@@ -531,7 +531,8 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				disposePointer( this._findPointerByMouseButton( mouseButton ) );
+				const pointer = this._findPointerByMouseButton( mouseButton );
+				pointer && disposePointer( pointer );
 
 			}
 
@@ -568,7 +569,8 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				disposePointer( this._findPointerByMouseButton( mouseButton ) );
+				const pointer = this._findPointerByMouseButton( mouseButton );
+				pointer && disposePointer( pointer );
 
 			}
 
@@ -698,7 +700,8 @@ export class CameraControls extends EventDispatcher {
 
 		const onPointerUp = ( event: PointerEvent ) => {
 
-			disposePointer( this._findPointerById( event.pointerId ) );
+			const pointer = this._findPointerById( event.pointerId );
+			pointer && disposePointer( pointer );
 
 			if ( event.pointerType === 'touch' ) {
 
@@ -738,7 +741,9 @@ export class CameraControls extends EventDispatcher {
 
 		const onMouseUp = () => {
 
-			disposePointer( this._findPointerById( 0 ) );
+			const pointer = this._findPointerById( 0 );
+			pointer && disposePointer( pointer );
+
 			this._state = ACTION.NONE;
 
 			endDragging();
@@ -834,7 +839,8 @@ export class CameraControls extends EventDispatcher {
 					event instanceof MouseEvent ? 0 :
 					0;
 
-				disposePointer( this._findPointerById( pointerId ) );
+				const pointer = this._findPointerById( pointerId );
+				pointer && disposePointer( pointer );
 
 				// eslint-disable-next-line no-undef
 				this._domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, { passive: false } as AddEventListenerOptions );


### PR DESCRIPTION
Add simple internal compatibility with [PointerLock API](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock) / [three.js PointerLockControls](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/PointerLockControls.js).

Currently CameraControls acknowledges PointerLock API in `onPointerMove` by calculating [delta values](https://github.com/yomotsu/camera-controls/blob/dev/src/CameraControls.ts#L993) - but since controls become reactive only after at least one `onPointerDown / onMouseDown` event - PointerLock's arguably most practical use-case, a first-person camera, is not achievable (user would need to hold down a button to make controls listen to events.)

Changes:
* `pointerlockchange` and `pointerlockerror` listeners ([source](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/PointerLockControls.js#L81))
* automatically listen to pointer movement when pointer lock is active (since `.requestPointerLock` doesn't require pointer event, also mock a pointer object internally if needed)
* add `pointer-lock` example (the only thing necessary to engage pointer-lock controls is to use `document.requestPointerLock()`, no changes to CameraControls API)

https://user-images.githubusercontent.com/9549760/219977456-7f5298f3-2e4c-46bc-98c5-6fd859109a27.mov

