### PR TITLE
expose lockPointer and unlockPointer methods

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -15,6 +15,8 @@
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.infinityDolly = this.checked">infinity dolly</label>
 	<br>
+	<label><input type="checkbox" onchange="cameraControls.dollyDragInverted = this.checked">dolly drag inverted</label>
+	<br>
 	<br>
 	<button onclick="cameraControls.rotate(  45 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta 45deg</button>
 	<button onclick="cameraControls.rotate( -90 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta -90deg</button>

--- a/examples/camera-up.html
+++ b/examples/camera-up.html
@@ -26,6 +26,7 @@
 	<br>
 	<button onclick="cameraControls.enabled = false;">disable mouse/touch controls</button>
 	<button onclick="cameraControls.enabled = true;">enable mouse/touch controls</button>
+	<button onclick="cameraControls.applyCameraUp()">applyCameraUp</button>
 </div>
 
 <script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>

--- a/examples/pointer-lock.html
+++ b/examples/pointer-lock.html
@@ -9,12 +9,24 @@
 <body>
 <div class="info">
 	<p><a href="https://github.com/yomotsu/camera-controls">GitHub repo</a></p>
-	<button onclick="void lockCursor()">lock pointer</button>
+	<button onclick="cameraControls.lockPointer()">lock pointer (auto move)</button><br>
+	<button onclick="renderer.domElement.requestPointerLock();">lock pointer (user dragging)</button><br>
+	<button onclick="cameraControls.reset( true )">reset</button>
 </div>
 
-<script src="https://unpkg.com/three@0.149.0/build/three.min.js"></script>
-<script src="../dist/camera-controls.js"></script>
-<script>
+<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+<script type="importmap">
+{
+	"imports": {
+		"three": "https://unpkg.com/three@0.149.0/build/three.module.js",
+		"three/addons/": "https://unpkg.com/three@0.149.0/examples/jsm/"
+	}
+}
+</script>
+<script type="module">
+import * as THREE from 'three';
+import gsap from "https://unpkg.com/gsap@3.10.4/index.js";
+import CameraControls from './dist/camera-controls.module.js';
 CameraControls.install( { THREE: THREE } );
 
 const width = window.innerWidth;
@@ -41,10 +53,6 @@ scene.add( gridHelper );
 
 renderer.render( scene, camera );
 
-function lockCursor () {
-	renderer.domElement.requestPointerLock();
-}
-
 ( function anim () {
 
 	const delta = clock.getDelta();
@@ -61,6 +69,9 @@ function lockCursor () {
 	}
 
 } )();
+
+globalThis.cameraControls = cameraControls;
+globalThis.renderer = renderer;
 </script>
 
 </body>

--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ See [the demo](https://github.com/yomotsu/camera-movement-comparison#dolly-vs-zo
 | `.truckSpeed`             | `number`  | `2.0`       | Speed of drag for truck and pedestal. |
 | `.verticalDragToForward`  | `boolean` | `false`     | The same as `.screenSpacePanning` in three.js's OrbitControls. |
 | `.dollyToCursor`          | `boolean` | `false`     | `true` to enable Dolly-in to the mouse cursor coords. |
+| `.dollyDragInverted`      | `boolean` | `false`     | `true` to invert direction when dollying or zooming via drag. |
 | `.colliderMeshes`         | `array`   | `[]`        | An array of Meshes to collide with camera ². |
 | `.infinityDolly`          | `boolean` | `false`     | `true` to enable Infinity Dolly ³. |
 | `.restThreshold`          | `number`  | `0.0025`    | Controls how soon the `rest` event fires as the camera slows |
@@ -644,6 +645,13 @@ Update camera position and directions. This should be called in your tick loop a
 #### `updateCameraUp()`
 
 When you change camera-up vector, run `.updateCameraUp()` to sync.
+
+---
+
+#### `applyCameraUp()`
+
+Apply current camera-up direction to the camera.  
+The orbit system will be re-initialized with the current position.
 
 ---
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -504,12 +504,6 @@ export class CameraControls extends EventDispatcher {
 		const lastDragPosition = new THREE.Vector2() as _THREE.Vector2;
 		const dollyStart = new THREE.Vector2() as _THREE.Vector2;
 
-		const disposePointer = ( pointer: PointerInput ) => {
-
-			this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
-
-		};
-
 		const onPointerDown = ( event: PointerEvent ) => {
 
 			if ( ! this._enabled || ! this._domElement ) return;
@@ -528,7 +522,7 @@ export class CameraControls extends EventDispatcher {
 			if ( mouseButton !== null ) {
 
 				const zombiePointer = this._findPointerByMouseButton( mouseButton );
-				zombiePointer && disposePointer( zombiePointer );
+				zombiePointer && this._disposePointer( zombiePointer );
 
 			}
 
@@ -569,7 +563,7 @@ export class CameraControls extends EventDispatcher {
 			if ( mouseButton !== null ) {
 
 				const zombiePointer = this._findPointerByMouseButton( mouseButton );
-				zombiePointer && disposePointer( zombiePointer );
+				zombiePointer && this._disposePointer( zombiePointer );
 
 			}
 
@@ -710,7 +704,7 @@ export class CameraControls extends EventDispatcher {
 
 			if ( pointer && pointer === this._lockedPointer ) return;
 
-			pointer && disposePointer( pointer );
+			pointer && this._disposePointer( pointer );
 
 			if ( event.pointerType === 'touch' ) {
 
@@ -754,7 +748,7 @@ export class CameraControls extends EventDispatcher {
 
 			if ( pointer && pointer === this._lockedPointer ) return;
 
-			pointer && disposePointer( pointer );
+			pointer && this._disposePointer( pointer );
 
 			this._state = ACTION.NONE;
 
@@ -852,7 +846,7 @@ export class CameraControls extends EventDispatcher {
 					0;
 
 				const pointer = this._findPointerById( pointerId );
-				pointer && disposePointer( pointer );
+				pointer && this._disposePointer( pointer );
 
 				// eslint-disable-next-line no-undef
 				this._domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, { passive: false } as AddEventListenerOptions );
@@ -1024,8 +1018,9 @@ export class CameraControls extends EventDispatcher {
 			// When pointer lock is enabled clientX, clientY, screenX, and screenY remain 0.
 			// If pointer lock is enabled, use the Delta directory, and assume active-pointer is not multiple.
 			const isPointerLockActive = this._domElement && document.pointerLockElement === this._domElement;
-			const deltaX = isPointerLockActive ? - ( this._lockedPointer || this._activePointers[ 0 ] ).deltaX : lastDragPosition.x - _v2.x;
-			const deltaY = isPointerLockActive ? - ( this._lockedPointer || this._activePointers[ 0 ] ).deltaY : lastDragPosition.y - _v2.y;
+			const lockedPointer = isPointerLockActive ? this._lockedPointer || this._activePointers[ 0 ] : null;
+			const deltaX = lockedPointer ? - lockedPointer.deltaX : lastDragPosition.x - _v2.x;
+			const deltaY = lockedPointer ? - lockedPointer.deltaY : lastDragPosition.y - _v2.y;
 
 			lastDragPosition.copy( _v2 );
 
@@ -1193,7 +1188,7 @@ export class CameraControls extends EventDispatcher {
 
 			if ( this._lockedPointer !== null ) {
 
-				disposePointer( this._lockedPointer );
+				this._disposePointer( this._lockedPointer );
 				this._lockedPointer = null;
 
 			}
@@ -2798,6 +2793,13 @@ export class CameraControls extends EventDispatcher {
 	protected _findPointerByMouseButton( mouseButton: MOUSE_BUTTON ): PointerInput | undefined {
 
 		return this._activePointers.find( ( activePointer ) => activePointer.mouseButton === mouseButton );
+
+	}
+
+
+	protected _disposePointer( pointer: PointerInput ): void {
+
+		this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
 
 	}
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -338,6 +338,8 @@ export class CameraControls extends EventDispatcher {
 	 */
 	// cancel will be overwritten in the constructor.
 	cancel: () => void = () => {};
+	lockPointer: () => void;
+	unlockPointer: () => void;
 
 	protected _enabled = true;
 	protected _camera: _THREE.PerspectiveCamera | _THREE.OrthographicCamera;
@@ -383,7 +385,9 @@ export class CameraControls extends EventDispatcher {
 	protected _updatedLastTime = false;
 	protected _elementRect = new DOMRect();
 
+	protected _isDragging = false;
 	protected _activePointers: PointerInput[] = [];
+	protected _lockedPointer: PointerInput | null = null;
 
 	// Use draggingSmoothTime over smoothTime while true.
 	// set automatically true on user-dragging start.
@@ -502,15 +506,6 @@ export class CameraControls extends EventDispatcher {
 
 		const disposePointer = ( pointer: PointerInput ) => {
 
-			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
-
-			if ( isPointerLockActive && this._activePointers.length <= 1 ) {
-
-				// NOTE Do not dispose pointer-locked pointer
-				return;
-
-			}
-
 			this._activePointers.splice( this._activePointers.indexOf( pointer ), 1 );
 
 		};
@@ -532,10 +527,12 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				const pointer = this._findPointerByMouseButton( mouseButton );
-				pointer && disposePointer( pointer );
+				const zombiePointer = this._findPointerByMouseButton( mouseButton );
+				zombiePointer && disposePointer( zombiePointer );
 
 			}
+
+			if ( ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT && this._lockedPointer ) return;
 
 			const pointer = {
 				pointerId: event.pointerId,
@@ -554,13 +551,14 @@ export class CameraControls extends EventDispatcher {
 			this._domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, { passive: false } );
 			this._domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
 
+			this._isDragging = true;
 			startDragging( event );
 
 		};
 
 		const onMouseDown = ( event: MouseEvent ) => {
 
-			if ( ! this._enabled || ! this._domElement ) return;
+			if ( ! this._enabled || ! this._domElement || this._lockedPointer ) return;
 
 			const mouseButton =
 				( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ? MOUSE_BUTTON.LEFT :
@@ -570,13 +568,13 @@ export class CameraControls extends EventDispatcher {
 
 			if ( mouseButton !== null ) {
 
-				const pointer = this._findPointerByMouseButton( mouseButton );
-				pointer && disposePointer( pointer );
+				const zombiePointer = this._findPointerByMouseButton( mouseButton );
+				zombiePointer && disposePointer( zombiePointer );
 
 			}
 
 			const pointer = {
-				pointerId: 0,
+				pointerId: 1,
 				clientX: event.clientX,
 				clientY: event.clientY,
 				deltaX: 0,
@@ -597,6 +595,7 @@ export class CameraControls extends EventDispatcher {
 			this._domElement.ownerDocument.addEventListener( 'mousemove', onMouseMove );
 			this._domElement.ownerDocument.addEventListener( 'mouseup', onMouseUp );
 
+			this._isDragging = true;
 			startDragging( event );
 
 		};
@@ -606,7 +605,7 @@ export class CameraControls extends EventDispatcher {
 			if ( event.cancelable ) event.preventDefault();
 
 			const pointerId = event.pointerId;
-			const pointer = this._findPointerById( pointerId );
+			const pointer = this._lockedPointer || this._findPointerById( pointerId );
 
 			if ( ! pointer ) return;
 
@@ -614,6 +613,8 @@ export class CameraControls extends EventDispatcher {
 			pointer.clientY = event.clientY;
 			pointer.deltaX = event.movementX;
 			pointer.deltaY = event.movementY;
+
+			this._state = 0;
 
 			if ( event.pointerType === 'touch' ) {
 
@@ -638,21 +639,22 @@ export class CameraControls extends EventDispatcher {
 
 			} else {
 
-				this._state = 0;
-
-				if ( ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ) {
+				if (
+					( ! this._isDragging && this._lockedPointer ) ||
+					this._isDragging && ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT
+				) {
 
 					this._state = this._state | this.mouseButtons.left;
 
 				}
 
-				if ( ( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ) {
+				if ( this._isDragging && ( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ) {
 
 					this._state = this._state | this.mouseButtons.middle;
 
 				}
 
-				if ( ( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ) {
+				if ( this._isDragging && ( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ) {
 
 					this._state = this._state | this.mouseButtons.right;
 
@@ -666,7 +668,7 @@ export class CameraControls extends EventDispatcher {
 
 		const onMouseMove = ( event: MouseEvent ) => {
 
-			const pointer = this._findPointerById( 0 );
+			const pointer = this._lockedPointer || this._findPointerById( 1 );
 
 			if ( ! pointer ) return;
 
@@ -677,7 +679,10 @@ export class CameraControls extends EventDispatcher {
 
 			this._state = 0;
 
-			if ( ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ) {
+			if (
+				this._lockedPointer ||
+				( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT
+			) {
 
 				this._state = this._state | this.mouseButtons.left;
 
@@ -702,6 +707,9 @@ export class CameraControls extends EventDispatcher {
 		const onPointerUp = ( event: PointerEvent ) => {
 
 			const pointer = this._findPointerById( event.pointerId );
+
+			if ( pointer && pointer === this._lockedPointer ) return;
+
 			pointer && disposePointer( pointer );
 
 			if ( event.pointerType === 'touch' ) {
@@ -742,7 +750,10 @@ export class CameraControls extends EventDispatcher {
 
 		const onMouseUp = () => {
 
-			const pointer = this._findPointerById( 0 );
+			const pointer = this._findPointerById( 1 );
+
+			if ( pointer && pointer === this._lockedPointer ) return;
+
 			pointer && disposePointer( pointer );
 
 			this._state = ACTION.NONE;
@@ -886,50 +897,50 @@ export class CameraControls extends EventDispatcher {
 
 			}
 
-			if ( event ) {
+			this._state = 0;
 
-				if ( 'pointerType' in event && event.pointerType === 'touch' ) {
+			if ( ! event ) {
 
-					switch ( this._activePointers.length ) {
+				if ( this._lockedPointer ) this._state = this._state | this.mouseButtons.left;
 
-						case 1:
+			} else if ( 'pointerType' in event && event.pointerType === 'touch' ) {
 
-							this._state = this.touches.one;
-							break;
+				switch ( this._activePointers.length ) {
 
-						case 2:
+					case 1:
 
-							this._state = this.touches.two;
-							break;
+						this._state = this.touches.one;
+						break;
 
-						case 3:
+					case 2:
 
-							this._state = this.touches.three;
-							break;
+						this._state = this.touches.two;
+						break;
 
-					}
+					case 3:
 
-				} else {
+						this._state = this.touches.three;
+						break;
 
-					this._state = 0;
+				}
 
-					if ( ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ) {
+			} else {
 
-						this._state = this._state | this.mouseButtons.left;
+				if ( ! this._lockedPointer && ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ) {
 
-					}
+					this._state = this._state | this.mouseButtons.left;
 
-					if ( ( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ) {
+				}
 
-						this._state = this._state | this.mouseButtons.middle;
+				if ( ( event.buttons & MOUSE_BUTTON.MIDDLE ) === MOUSE_BUTTON.MIDDLE ) {
 
-					}
+					this._state = this._state | this.mouseButtons.middle;
 
-					if ( ( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ) {
+				}
 
-						this._state = this._state | this.mouseButtons.right;
+				if ( ( event.buttons & MOUSE_BUTTON.RIGHT ) === MOUSE_BUTTON.RIGHT ) {
 
-					}
+					this._state = this._state | this.mouseButtons.right;
 
 				}
 
@@ -1013,8 +1024,8 @@ export class CameraControls extends EventDispatcher {
 			// When pointer lock is enabled clientX, clientY, screenX, and screenY remain 0.
 			// If pointer lock is enabled, use the Delta directory, and assume active-pointer is not multiple.
 			const isPointerLockActive = this._domElement && document.pointerLockElement === this._domElement;
-			const deltaX = isPointerLockActive ? - this._activePointers[ 0 ].deltaX : lastDragPosition.x - _v2.x;
-			const deltaY = isPointerLockActive ? - this._activePointers[ 0 ].deltaY : lastDragPosition.y - _v2.y;
+			const deltaX = isPointerLockActive ? - ( this._lockedPointer || this._activePointers[ 0 ] ).deltaX : lastDragPosition.x - _v2.x;
+			const deltaY = isPointerLockActive ? - ( this._lockedPointer || this._activePointers[ 0 ] ).deltaY : lastDragPosition.y - _v2.y;
 
 			lastDragPosition.copy( _v2 );
 
@@ -1022,8 +1033,7 @@ export class CameraControls extends EventDispatcher {
 				( this._state & ACTION.ROTATE ) === ACTION.ROTATE ||
 				( this._state & ACTION.TOUCH_ROTATE ) === ACTION.TOUCH_ROTATE ||
 				( this._state & ACTION.TOUCH_DOLLY_ROTATE ) === ACTION.TOUCH_DOLLY_ROTATE ||
-				( this._state & ACTION.TOUCH_ZOOM_ROTATE ) === ACTION.TOUCH_ZOOM_ROTATE ||
-				isPointerLockActive
+				( this._state & ACTION.TOUCH_ZOOM_ROTATE ) === ACTION.TOUCH_ZOOM_ROTATE
 			) {
 
 				this._rotateInternal( deltaX, deltaY );
@@ -1124,6 +1134,15 @@ export class CameraControls extends EventDispatcher {
 			extractClientCoordFromEvent( this._activePointers, _v2 );
 			lastDragPosition.copy( _v2 );
 
+			if (
+				this._activePointers.length === 0 ||
+				( this._activePointers.length === 1 && this._activePointers[ 0 ] === this._lockedPointer )
+			) {
+
+				this._isDragging = false;
+
+			}
+
 			if ( this._activePointers.length === 0 && this._domElement ) {
 
 				// eslint-disable-next-line no-undef
@@ -1138,25 +1157,30 @@ export class CameraControls extends EventDispatcher {
 
 		};
 
-		const lockPointer = (): void => {
+		this.lockPointer = (): void => {
 
 			if ( ! this._enabled || ! this._domElement ) return;
 
 			this.cancel();
 
 			// Element.requestPointerLock is allowed to happen without any pointer active - create a faux one for compatibility with controls
-			const pointer: PointerInput = {
-				pointerId: 1,
+			this._lockedPointer = {
+				pointerId: - 1,
 				clientX: 0,
 				clientY: 0,
 				deltaX: 0,
 				deltaY: 0,
-				mouseButton: null
+				mouseButton: null,
 			};
-			this._activePointers.push( pointer );
+			this._activePointers.push( this._lockedPointer );
 
+			// eslint-disable-next-line no-undef
 			this._domElement.ownerDocument.removeEventListener( 'pointermove', onPointerMove, { passive: false } as AddEventListenerOptions );
 			this._domElement.ownerDocument.removeEventListener( 'pointerup', onPointerUp );
+
+			this._domElement.requestPointerLock();
+			this._domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerLockChange );
+			this._domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerLockError );
 
 			this._domElement.ownerDocument.addEventListener( 'pointermove', onPointerMove, { passive: false } );
 			this._domElement.ownerDocument.addEventListener( 'pointerup', onPointerUp );
@@ -1165,30 +1189,35 @@ export class CameraControls extends EventDispatcher {
 
 		};
 
-		const unlockPointer = (): void => {
+		this.unlockPointer = (): void => {
+
+			if ( this._lockedPointer !== null ) {
+
+				disposePointer( this._lockedPointer );
+				this._lockedPointer = null;
+
+			}
+
+			document.exitPointerLock();
 
 			this.cancel();
+
+			if ( ! this._domElement ) return;
+			this._domElement.ownerDocument.removeEventListener( 'pointerlockchange', onPointerLockChange );
+			this._domElement.ownerDocument.removeEventListener( 'pointerlockerror', onPointerLockError );
 
 		};
 
 		const onPointerLockChange = (): void => {
 
 			const isPointerLockActive = this._domElement && this._domElement.ownerDocument.pointerLockElement === this._domElement;
-			if ( isPointerLockActive ) {
-
-				lockPointer();
-
-			} else {
-
-				unlockPointer();
-
-			}
+			if ( ! isPointerLockActive ) this.unlockPointer();
 
 		};
 
 		const onPointerLockError = (): void => {
 
-			unlockPointer();
+			this.unlockPointer();
 
 		};
 
@@ -1205,9 +1234,6 @@ export class CameraControls extends EventDispatcher {
 			this._domElement.addEventListener( 'pointercancel', onPointerUp );
 			this._domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 			this._domElement.addEventListener( 'contextmenu', onContextMenu );
-
-			this._domElement.ownerDocument.addEventListener( 'pointerlockchange', onPointerLockChange );
-			this._domElement.ownerDocument.addEventListener( 'pointerlockerror', onPointerLockError );
 
 		};
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -345,7 +345,19 @@ export class CameraControls extends EventDispatcher {
 	 */
 	// cancel will be overwritten in the constructor.
 	cancel: () => void = () => {};
+
+	/**
+	 * Still an experimental feature.
+	 * This could change at any time.
+	 * @category Methods
+	 */
 	lockPointer: () => void;
+
+	/**
+	 * Still an experimental feature.
+	 * This could change at any time.
+	 * @category Methods
+	 */
 	unlockPointer: () => void;
 
 	protected _enabled = true;


### PR DESCRIPTION
- `lockPointer()` and `unlockPointer()` are now public methods.
- Previously, the pointer created with PointerLock was an ordinary pointer and could be accidentally removed, but I added the `this._lockedPointer` field as an instance of the special pointer, to save from the problem.
- accept the right button dragging

https://user-images.githubusercontent.com/212837/223721937-89f6680c-4427-4fa6-a723-52b82c98d10e.mp4

