### PR TITLE
fix: updateCameraUp doesnt update _yAxisUpSpaceInverse

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2307,7 +2307,7 @@ export class CameraControls extends EventDispatcher {
 	updateCameraUp(): void {
 
 		this._yAxisUpSpace.setFromUnitVectors( this._camera.up, _AXIS_Y );
-		this._yAxisUpSpaceInverse.copy( this._yAxisUpSpace ).invert;
+		this._yAxisUpSpaceInverse.copy( this._yAxisUpSpace ).invert();
 
 	}
 


### PR DESCRIPTION
reported in https://github.com/yomotsu/camera-controls/issues/389

`updateCameraUp()` didn't work correctly because it doesn't update yAxisUpSpaceInverse due to typo.
The problem was caused by https://github.com/yomotsu/camera-controls/commit/6b8aa4f8678f7b7765bb7144705851e8924f3f6a#diff-a7487850c504598a4d5cfd4300c570c2cfeebab9cb158675a7ef8a30faac4d8cR2204