### PR TITLE
Add dollyDragInverted property

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -15,6 +15,8 @@
 	<br>
 	<label><input type="checkbox" onchange="cameraControls.infinityDolly = this.checked">infinity dolly</label>
 	<br>
+	<label><input type="checkbox" onchange="cameraControls.dollyDragInverted = this.checked">dolly drag inverted</label>
+	<br>
 	<br>
 	<button onclick="cameraControls.rotate(  45 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta 45deg</button>
 	<button onclick="cameraControls.rotate( -90 * THREE.MathUtils.DEG2RAD, 0, true )">rotate theta -90deg</button>

--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,7 @@ See [the demo](https://github.com/yomotsu/camera-movement-comparison#dolly-vs-zo
 | `.truckSpeed`             | `number`  | `2.0`       | Speed of drag for truck and pedestal. |
 | `.verticalDragToForward`  | `boolean` | `false`     | The same as `.screenSpacePanning` in three.js's OrbitControls. |
 | `.dollyToCursor`          | `boolean` | `false`     | `true` to enable Dolly-in to the mouse cursor coords. |
+| `.dollyDragInverted`      | `boolean` | `false`     | `true` to invert direction when dollying or zooming via drag. |
 | `.colliderMeshes`         | `array`   | `[]`        | An array of Meshes to collide with camera ². |
 | `.infinityDolly`          | `boolean` | `false`     | `true` to enable Infinity Dolly ³. |
 | `.restThreshold`          | `number`  | `0.0025`    | Controls how soon the `rest` event fires as the camera slows |

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -256,6 +256,13 @@ export class CameraControls extends EventDispatcher {
 	 * @category Properties
 	 */
 	dollySpeed = 1.0;
+
+	/**
+	 * `true` to invert direction when dollying or zooming via drag
+	 * @category Properties
+	 */
+	dollyDragInverted = false;
+
 	/**
 	 * Speed of drag for truck and pedestal.
 	 * @category Properties
@@ -1018,14 +1025,16 @@ export class CameraControls extends EventDispatcher {
 
 				const dollyX = this.dollyToCursor ? ( dragStartPosition.x - this._elementRect.x ) / this._elementRect.width  *   2 - 1 : 0;
 				const dollyY = this.dollyToCursor ? ( dragStartPosition.y - this._elementRect.y ) / this._elementRect.height * - 2 + 1 : 0;
+				const dollyDirection = this.dollyDragInverted ? - 1 : 1;
+
 				if ( ( this._state & ACTION.DOLLY ) === ACTION.DOLLY ) {
 
-					this._dollyInternal( deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
+					this._dollyInternal( dollyDirection * deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
 					this._isUserControllingDolly = true;
 
 				} else {
 
-					this._zoomInternal( deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
+					this._zoomInternal( dollyDirection * deltaY * TOUCH_DOLLY_FACTOR, dollyX, dollyY );
 					this._isUserControllingZoom = true;
 
 				}


### PR DESCRIPTION
At present, when dollying/zooming via drag, pressing the mouse button and dragging up dollies/zooms out and dragging down dollies/zooms in.

However, this is the opposite of how 3D design software from Autodesk and others work, so the new `dollyDragInverted` property enables developers to invert this functionality, so that dragging up dollies/zooms in and down dollies/zooms out.

This update does not affect dollying/zooming via the mouse wheel.

A checkbox has been added to the basic example to demonstrate this functionality.