### PR TITLE
chore(release): actions/setup-node reads .node-version file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
           cache: "npm"
       - id: main
         run: |


### PR DESCRIPTION
so there is no need to hard-code it into the workflow file: https://stackoverflow.com/a/62978089/133327