### PR TITLE
fix: dollyToCursor will lose the pan smoothness

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2586,9 +2586,11 @@ export class CameraControls extends EventDispatcher {
 					const cursor = _v3A.copy( this._targetEnd )
 						.add( planeX.multiplyScalar( this._dollyControlCoord.x * worldToScreen * camera.aspect ) )
 						.add( planeY.multiplyScalar( this._dollyControlCoord.y * worldToScreen ) );
-					this._targetEnd.lerp( cursor, lerpRatio );
+					const newTargetEnd = _v3B.copy( this._targetEnd ).lerp( cursor, lerpRatio );
+					const targetEndDiff = _v3C.subVectors( newTargetEnd, this._targetEnd );
+					this._targetEnd.copy( newTargetEnd );
+					this._target.add( targetEndDiff );
 
-					this._target.copy( this._targetEnd );
 					// target position may be moved beyond boundary.
 					this._boundary.clampPoint( this._targetEnd, this._targetEnd );
 


### PR DESCRIPTION
see https://github.com/yomotsu/camera-controls/issues/421

This PR is to fix the problem reported in issue 421

Before: the problem is reproduced
https://github.com/yomotsu/camera-controls/assets/212837/e20658a0-7e23-4292-bcd5-1fc861975213

After: the problem should be fixed
https://github.com/yomotsu/camera-controls/assets/212837/a3d5b21b-ece7-44a9-8927-908434d3e3c5

