### PR TITLE
fix: setTarget moves the camera to unexpected positions by the angle

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2205,7 +2205,7 @@ export class CameraControls extends EventDispatcher {
 		);
 
 		// see https://github.com/yomotsu/camera-controls/issues/335
-		this._sphericalEnd.phi = clamp( this.polarAngle, this.minPolarAngle, this.maxPolarAngle );
+		this._sphericalEnd.phi = clamp( this._sphericalEnd.phi, this.minPolarAngle, this.maxPolarAngle );
 
 		return promise;
 


### PR DESCRIPTION
related to https://github.com/yomotsu/camera-controls/issues/425