### PR TITLE
fix: use local clamp instead of MathUtils clamp

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -3200,7 +3200,7 @@ export class CameraControls extends EventDispatcher {
 		const dollyScale = Math.pow( 0.95, - delta * this.dollySpeed );
 		const lastDistance = this._sphericalEnd.radius;
 		const distance = this._sphericalEnd.radius * dollyScale;
-		const clampedDistance = THREE.MathUtils.clamp( distance, this.minDistance, this.maxDistance );
+		const clampedDistance = clamp( distance, this.minDistance, this.maxDistance );
 		const overflowedDistance = clampedDistance - distance;
 
 		if ( this.infinityDolly && this.dollyToCursor ) {


### PR DESCRIPTION
follow up from https://github.com/yomotsu/camera-controls/pull/448

using internal clamp function instead of THREE.MathUtils.clamp()

 