### PR TITLE
Re-normalize new camera up after cross product

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2610,7 +2610,7 @@ export class CameraControls extends EventDispatcher {
 		const side = _v3B.crossVectors( cameraDirection, this._camera.up );
 		// Then find the vector orthogonal to both this "side" vector and the "view" vector.
 		// This vector will be the new "up" vector.
-		this._camera.up.crossVectors( side, cameraDirection );
+		this._camera.up = _v3C.crossVectors( side, cameraDirection ).normalize();
 		this._camera.updateMatrixWorld();
 
 		const position = this.getPosition( _v3A );

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2610,7 +2610,7 @@ export class CameraControls extends EventDispatcher {
 		const side = _v3B.crossVectors( cameraDirection, this._camera.up );
 		// Then find the vector orthogonal to both this "side" vector and the "view" vector.
 		// This vector will be the new "up" vector.
-		this._camera.up = _v3C.crossVectors( side, cameraDirection ).normalize();
+		this._camera.up.crossVectors( side, cameraDirection ).normalize();
 		this._camera.updateMatrixWorld();
 
 		const position = this.getPosition( _v3A );


### PR DESCRIPTION
After running `applyCameraUp`, the `_camera.up` vector gets used to create a quaternion in `updateCameraUp` via `setFromUnitVectors` - since the cross product of two vectors isn't normalized unless the two vectors are orthogonal two eachother, the resulting `_camera.up` ends up being non-normal, and causes the quaternion generation to get upset. This change just re-normalizes the output of the cross product.