### PR TITLE
fix: deprecated geometry from examples

### DIFF
--- a/examples/await-transitions.html
+++ b/examples/await-transitions.html
@@ -52,7 +52,7 @@ function init() {
 	cameraControls = new CameraControls( camera, renderer.domElement );
 
 	mesh = new THREE.Mesh(
-		new THREE.BoxBufferGeometry( 1, 1, 1 ),
+		new THREE.BoxGeometry( 1, 1, 1 ),
 		new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
 	);
 	scene.add( mesh );

--- a/examples/fit-to-bounding-sphere.html
+++ b/examples/fit-to-bounding-sphere.html
@@ -66,7 +66,7 @@ new GLTFLoader().load( './rubber-duck.glb', function ( gltf ) {
 
 	const boundingSphere = CameraControls.createBoundingSphere( gltf.scene );
 	const sphereHelper = new THREE.Mesh(
-		new THREE.SphereBufferGeometry( boundingSphere.radius, 16, 16 ),
+		new THREE.SphereGeometry( boundingSphere.radius, 16, 16 ),
 		new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
 	);
 	sphereHelper.position.copy( boundingSphere.center );

--- a/examples/rest-and-sleep.html
+++ b/examples/rest-and-sleep.html
@@ -48,7 +48,7 @@ document.body.appendChild( renderer.domElement );
 const cameraControls = new CameraControls( camera, renderer.domElement );
 
 const mesh = new THREE.Mesh(
-	new THREE.BoxBufferGeometry( 1, 1, 1 ),
+	new THREE.BoxGeometry( 1, 1, 1 ),
 	new THREE.MeshBasicMaterial( { color: 0xff0000, wireframe: true } )
 );
 scene.add( mesh );


### PR DESCRIPTION
BoxBufferGeometry -> BoxGeometry
SphereBufferGeometry -> SphereGeometry

I found this after looking at the fit-to-bounding-sphere example and got the error:
Uncaught (in promise) TypeError: THREE.SphereBufferGeometry is not a constructor
    at fit-to-bounding-sphere.html:69:3