### PR TITLE
fix: prevent divide-by-zero

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2992,6 +2992,7 @@ export class CameraControls extends EventDispatcher {
 
 		domElement.setAttribute( 'data-camera-controls-version', VERSION );
 		this._addAllEventListeners( domElement );
+		this._getClientRect( this._elementRect );
 
 	}
 


### PR DESCRIPTION
The height of `_elementRect` will be used as a divisor but could be 0 until `_elementRect` is initialized.
thus _elementRect should be updated right after connecting to the dom.