### PR TITLE
Change mouse button config to a function `(e: Event) => ACTION`

### DIFF
--- a/examples/mouse-drag-with-modifier-keys.html
+++ b/examples/mouse-drag-with-modifier-keys.html
@@ -41,53 +41,50 @@ const renderer = new THREE.WebGLRenderer();
 renderer.setSize( width, height );
 document.body.appendChild( renderer.domElement );
 
+const MOUSE_BUTTON = {
+	LEFT: 1,
+	RIGHT: 2,
+	MIDDLE: 4,
+}
+const ACTION = CameraControls.ACTION
+
 const cameraControls = new CameraControls( camera, renderer.domElement );
 
-// switch the behavior by the modifier key press
-const keyState = {
-	shiftRight  : false,
-	shiftLeft   : false,
-	controlRight: false,
-	controlLeft : false,
-};
+const originalFunction = cameraControls.mouseEventToAction
 
-const updateConfig = () => {
+cameraControls.mouseEventToAction = event => {
 
-	if ( keyState.shiftRight || keyState.shiftLeft ) {
+	if ( event instanceof WheelEvent ) {
 
-		cameraControls.mouseButtons.left = CameraControls.ACTION.TRUCK;
-
-	} else if ( keyState.controlRight || keyState.controlLeft ) {
-
-		cameraControls.mouseButtons.left = CameraControls.ACTION.DOLLY;
-
-	} else {
-
-		cameraControls.mouseButtons.left = CameraControls.ACTION.ROTATE;
+		return originalFunction(event);
 
 	}
 
-}
+	if ( event instanceof MouseEvent ) {
 
-document.addEventListener( 'keydown', ( event ) => {
+		if ( ( event.buttons & MOUSE_BUTTON.LEFT ) === MOUSE_BUTTON.LEFT ) {
 
-	if ( event.code === 'ShiftRight'   ) keyState.shiftRight   = true;
-	if ( event.code === 'ShiftLeft'    ) keyState.shiftLeft    = true;
-	if ( event.code === 'ControlRight' ) keyState.controlRight = true;
-	if ( event.code === 'ControlLeft'  ) keyState.controlLeft  = true;
-	updateConfig();
+			if (event.shiftKey) {
 
-} );
+				return ACTION.TRUCK;
 
-document.addEventListener( 'keyup', ( event ) => {
+			}
 
-	if ( event.code === 'ShiftRight'   ) keyState.shiftRight   = false;
-	if ( event.code === 'ShiftLeft'    ) keyState.shiftLeft    = false;
-	if ( event.code === 'ControlRight' ) keyState.controlRight = false;
-	if ( event.code === 'ControlLeft'  ) keyState.controlLeft  = false;
-	updateConfig();
+			if (event.ctrlKey) {
 
-} );
+				return ACTION.DOLLY;
+
+			}
+
+			return ACTION.ROTATE;
+
+		}
+
+	}
+
+	return originalFunction(event);
+
+};
 
 const mesh = new THREE.Mesh(
 	new THREE.BoxGeometry( 1, 1, 1 ),

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export const MOUSE_BUTTON = {
 	LEFT: 1,
 	RIGHT: 2,
 	MIDDLE: 4,
+	ALL: 7,
 } as const;
 export type MOUSE_BUTTON = typeof MOUSE_BUTTON[ keyof typeof MOUSE_BUTTON ];
 


### PR DESCRIPTION
Regarding #458,

I propose a new structure for configuring mouse buttons. Instead of a configuration object, user can pass a configuration _function_ which receives an `Event` (either wheel event, click event, or contextmenu event) and which returns the intended action they want. With this, user can access `event.shiftKey` and all other modifier key flags and reliably set them without overly verbose configuration.

I have also updated the example at `examples/mouse-drag-with-modifier-keys.html` to show how it could be used.

Lastly, I wrote a custom setter for the previous configuration, `mouseButtons`, so that this is not a breaking change.

I'm not familiar with the coding conventions of this project, so please excuse if I didn't document something correctly. I look forward to hearing your feedback on my proposal!