### PR TITLE
Bugfix for incorrect "lookInDirectionOf" behaviour when camera orbit target is not at origin

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -1976,7 +1976,7 @@ export class CameraControls extends EventDispatcher {
 
 		const point = _v3A.set( x, y, z );
 		const direction = point.sub( this._targetEnd ).normalize();
-		const position = direction.multiplyScalar( - this._sphericalEnd.radius );
+		const position = direction.multiplyScalar( - this._sphericalEnd.radius ).add( this._targetEnd );
 		return this.setPosition( position.x, position.y, position.z, enableTransition );
 
 	}


### PR DESCRIPTION
Reproduction/demonstration of the bug: https://jsfiddle.net/wellcaffeinated/zdb05n2u/

Correctly works when orbit target (green box) is at origin. But when moved (elevate), the look direction is improperly calculated.

This fixes the problem with the vector math. 