### PR TITLE
chore: there's a typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -540,7 +540,7 @@ Similar to `setLookAt`, but it interpolates between two states.
 #### `setPosition( positionX, positionY, positionZ, enableTransition )`
 
 Set angle and distance by given position.
-An alias of 1setLookAt()1, without target change. Thus keep gazing at the current target
+An alias of `setLookAt()`, without target change. Thus keep gazing at the current target
 
 | Name               | Type      | Description |
 | ------------------ | --------- | ----------- |


### PR DESCRIPTION
This markdown seems to have been written by mistake.

```diff
- An alias of 1setLookAt()1, without target change.
+ An alias of `setLookAt()`, without target change.
```