### PR TITLE
fix: reset focal offsets on input start and setLookAt

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -3222,7 +3222,7 @@ export class CameraControls extends EventDispatcher {
 
 	// Applies and resets focal offsets to play nice with lookAt and zoom-to-cursor
 	// https://github.com/yomotsu/camera-controls/issues/491
-	_resetFocalOffsets() {
+	protected _resetFocalOffsets() {
 
 			_v3A.set( 0, 0, -1 ).applyQuaternion( this._camera.quaternion );
 			_v3A.multiplyScalar( this._spherical.radius );

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -723,6 +723,8 @@ export class CameraControls extends EventDispatcher {
 			if ( ! this._domElement ) return;
 			if ( ! this._enabled || this.mouseButtons.wheel === ACTION.NONE ) return;
 
+			this._resetFocalOffsets();
+
 			if (
 				this._interactiveArea.left !== 0 ||
 				this._interactiveArea.top !== 0 ||
@@ -842,6 +844,8 @@ export class CameraControls extends EventDispatcher {
 		const startDragging = ( event?: PointerEvent ): void => {
 
 			if ( ! this._enabled ) return;
+
+			this._resetFocalOffsets();
 
 			extractClientCoordFromEvent( this._activePointers, _v2 );
 
@@ -2034,6 +2038,8 @@ export class CameraControls extends EventDispatcher {
 		enableTransition: boolean = false,
 	): Promise<void> {
 
+		this._resetFocalOffsets();
+
 		this._isUserControllingRotate = false;
 		this._isUserControllingDolly = false;
 		this._isUserControllingTruck = false;
@@ -3213,6 +3219,19 @@ export class CameraControls extends EventDispatcher {
 	protected _addAllEventListeners( _domElement: HTMLElement ): void {}
 
 	protected _removeAllEventListeners(): void {}
+
+	// Applies and resets focal offsets to play nice with lookAt and zoom-to-cursor
+	// https://github.com/yomotsu/camera-controls/issues/491
+	_resetFocalOffsets() {
+
+			_v3A.set( 0, 0, -1 ).applyQuaternion( this._camera.quaternion );
+			_v3A.multiplyScalar( this._spherical.radius );
+			_v3A.add( this._camera.position );
+
+			this.setFocalOffset( 0, 0, 0, false );
+			this.moveTo( _v3A.x, _v3A.y, _v3A.z, false );
+
+	}
 
 	/**
 	 * backward compatible


### PR DESCRIPTION
Fixes #303
Fixes #316
Fixes #424
Fixes #491

Applies and zeroes focal offsets into the control's spherical coordinates so features like zoom-to-cursor (e.g. `setOrbitPoint` and then interacting with an `OrthographicCamera`) and `setLookAt` work without interruption. I have not tested `setLookAt` as thoroughly, but expanded the fix to it after reading #303.