### PR TITLE
feat(fitToSphere): add scale parameter to support scaling functionality

### DIFF
--- a/examples/fit-to-bounding-sphere.html
+++ b/examples/fit-to-bounding-sphere.html
@@ -12,6 +12,8 @@
 <div class="info">
 	<a href="https://github.com/yomotsu/camera-controls">GitHub repo</a><br>
 	<button onclick="fit()">fit</button>
+	<button onclick="fit(0.5)">fit with scale 0.5</button>
+	<button onclick="fit(1.2)">fit with scale 1.2</button>
 	<button onclick="cameraControls.reset( true )">reset</button><br>
 </div>
 
@@ -74,9 +76,17 @@ new GLTFLoader().load( './rubber-duck.glb', function ( gltf ) {
 	scene.add( gltf.scene );
 	scene.add( sphereHelper );
 
-	window.fit = function() {
+	window.fit = function( scale ) {
 
-		cameraControls.fitToSphere( gltf.scene, true );
+		if( typeof scale === 'number' ) {
+
+			cameraControls.fitToSphere( gltf.scene, true, { scale } );
+
+		} else {
+
+			cameraControls.fitToSphere( gltf.scene, true );
+
+		}
 
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -487,7 +487,7 @@ set `cover: true` to fill enter screen.
 
 ---
 
-#### `fitToSphere( sphereOrMesh, enableTransition )`
+#### `fitToSphere( sphereOrMesh, enableTransition, { scale } )`
 
 Fit the viewport to the sphere or the bounding sphere of the object.
 
@@ -495,6 +495,8 @@ Fit the viewport to the sphere or the bounding sphere of the object.
 | ------------------ | ------------------------------ | ----------- |
 | `sphereOrMesh`     | `THREE.Sphere` \| `THREE.Mesh` | bounding sphere to fit the view. |
 | `enableTransition` | `boolean`                      | Whether to move smoothly or immediately |
+| `options`          | `object`                       | Options |
+| `options.scale`    | `number`                       | View scale. Default is `1` |
 
 ---
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -8,10 +8,11 @@ import {
 	PointerInput,
 	MouseButtons,
 	Touches,
-	FitToOptions,
 	CameraControlsEventMap,
 	isPerspectiveCamera,
 	isOrthographicCamera,
+	FitToSphereOptions,
+	FitToBoxOptions,
 } from './types';
 import {
 	PI_2,
@@ -1867,7 +1868,7 @@ export class CameraControls extends EventDispatcher {
 		paddingRight = 0,
 		paddingBottom = 0,
 		paddingTop = 0
-	}: Partial<FitToOptions> = {} ): Promise<void[]> {
+	}: Partial<FitToBoxOptions> = {} ): Promise<void[]> {
 
 		const promises: Promise<void>[] = [];
 		const aabb = ( box3OrObject as _THREE.Box3 ).isBox3
@@ -1979,15 +1980,20 @@ export class CameraControls extends EventDispatcher {
 	 * Fit the viewport to the sphere or the bounding sphere of the object.
 	 * @param sphereOrMesh
 	 * @param enableTransition
+	 * @param options | `<object>` { scale: number }
 	 * @category Methods
 	 */
-	fitToSphere( sphereOrMesh: _THREE.Sphere | _THREE.Object3D, enableTransition: boolean ): Promise<void[]> {
+	fitToSphere( sphereOrMesh: _THREE.Sphere | _THREE.Object3D, enableTransition: boolean, {
+		scale = 1
+	}: Partial<FitToSphereOptions> = {} ): Promise<void[]> {
 
 		const promises: Promise<void>[] = [];
 		const isObject3D = 'isObject3D' in sphereOrMesh;
 		const boundingSphere = isObject3D ?
 			CameraControls.createBoundingSphere( sphereOrMesh as _THREE.Object3D, _sphere ) :
 			_sphere.copy( sphereOrMesh as _THREE.Sphere );
+
+		boundingSphere.radius /= scale;
 
 		promises.push( this.moveTo(
 			boundingSphere.center.x,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,12 +95,16 @@ export const DOLLY_DIRECTION = {
 } as const;
 export type DOLLY_DIRECTION = typeof DOLLY_DIRECTION[ keyof typeof DOLLY_DIRECTION ];
 
-export interface FitToOptions {
+export interface FitToBoxOptions {
 	cover: boolean;
 	paddingLeft  : number;
 	paddingRight : number;
 	paddingBottom: number;
 	paddingTop   : number;
+}
+
+export interface FitToSphereOptions {
+	scale: number;
 }
 
 export interface CameraControlsEventMap {


### PR DESCRIPTION
This is my current code:

```
const tempSphere = new Sphere()
CameraControls.createBoundingSphere(myMesh, tempSphere)
tempSphere.radius /= 0.8
cameraControls.fitToSphere(tempSphere, true)
```



I'm looking for a simpler code:

```
cameraControls.fitToSphere(myMesh, true, { scale: 0.8 })
```



So, I created this PR.

For the newly added parameter, I chose to use `{ scale: number }` instead of `scale:number` so that we can expand it to more parameters in the future if necessary.