### PR TITLE
Fix truckSpeed for orthographic camera

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -3036,8 +3036,8 @@ export class CameraControls extends EventDispatcher {
 
 			const camera = this._camera;
 
-			truckX    = deltaX * ( camera.right - camera.left   ) / camera.zoom / this._elementRect.width;
-			pedestalY = deltaY * ( camera.top   - camera.bottom ) / camera.zoom / this._elementRect.height;
+			truckX    = this.truckSpeed * deltaX * ( camera.right - camera.left   ) / camera.zoom / this._elementRect.width;
+			pedestalY = this.truckSpeed * deltaY * ( camera.top   - camera.bottom ) / camera.zoom / this._elementRect.height;
 
 		} else {
 


### PR DESCRIPTION
Previously truckSpeed parameter had no effect on the orthographicCamera

Tested in the ortho example, behavior is the same as basic.html ( Perspective )