### PR TITLE
fix: Re-added _camera.updateMatrixWorld() as via _camera.matrix.compose()

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2745,6 +2745,8 @@ export class CameraControls extends EventDispatcher {
 			! approxZero( this._focalOffset.z );
 		if ( affectOffset ) {
 
+			this._camera.matrix.compose( this._camera.position, this._camera.quaternion, this._camera.scale );
+
 			_xColumn.setFromMatrixColumn( this._camera.matrix, 0 );
 			_yColumn.setFromMatrixColumn( this._camera.matrix, 1 );
 			_zColumn.setFromMatrixColumn( this._camera.matrix, 2 );


### PR DESCRIPTION
As a result of #556, there is some *wobbling* when rapidly rotating the scene (if using focalOffset). Re-adding the earlier call to `_camera.updateMatrixWorld` fixes this.

This PR directly calls `_camera.matrix.compose` rather than calling `updateMatrixWorld` to avoid unnecessary calculations.

Regards,
Harrison