### PR TITLE
fix: trackpad pinch to zoom speed

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -756,7 +756,7 @@ export class CameraControls extends EventDispatcher {
 
 			// Ref: https://github.com/cedricpinson/osgjs/blob/00e5a7e9d9206c06fdde0436e1d62ab7cb5ce853/sources/osgViewer/input/source/InputSourceMouse.js#L89-L103
 			const deltaYFactor = isMac ? - 1 : - 3;
-			const delta = ( event.deltaMode === 1 ) ? event.deltaY / deltaYFactor : event.deltaY / ( deltaYFactor * 10 );
+			const delta = ( event.deltaMode === 1 || event.ctrlKey ) ? event.deltaY / deltaYFactor : event.deltaY / ( deltaYFactor * 10 );
 			const x = this.dollyToCursor ? ( event.clientX - this._elementRect.x ) / this._elementRect.width  *   2 - 1 : 0;
 			const y = this.dollyToCursor ? ( event.clientY - this._elementRect.y ) / this._elementRect.height * - 2 + 1 : 0;
 
@@ -2756,6 +2756,7 @@ export class CameraControls extends EventDispatcher {
 			this._camera.position.add( _v3A );
 
 			this._camera.updateMatrixWorld();
+
 		}
 
 		if ( this._boundaryEnclosesCamera ) {

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -756,6 +756,7 @@ export class CameraControls extends EventDispatcher {
 
 			// Ref: https://github.com/cedricpinson/osgjs/blob/00e5a7e9d9206c06fdde0436e1d62ab7cb5ce853/sources/osgViewer/input/source/InputSourceMouse.js#L89-L103
 			const deltaYFactor = isMac ? - 1 : - 3;
+			// Checks event.ctrlKey to detect multi-touch gestures on a trackpad.
 			const delta = ( event.deltaMode === 1 || event.ctrlKey ) ? event.deltaY / deltaYFactor : event.deltaY / ( deltaYFactor * 10 );
 			const x = this.dollyToCursor ? ( event.clientX - this._elementRect.x ) / this._elementRect.width  *   2 - 1 : 0;
 			const y = this.dollyToCursor ? ( event.clientY - this._elementRect.y ) / this._elementRect.height * - 2 + 1 : 0;


### PR DESCRIPTION
This aims to fix the issues #519 #461 where using the trackpad to zoom is very slow compared to the mouse wheel.

Fixed it by checking `ctrlKey` in the event and increasing the delta. This property is set by the browser to true when using multi touch gestures on the trackpad.

Since both issues reference using an orthographic camera and I'm using one myself in my project this needs to be tested using a perspective camera as well. I will try and find time to do it