### PR TITLE
fix: incorrect camera direction on boundary zoom

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2775,7 +2775,8 @@ export class CameraControls extends EventDispatcher {
 				_v3A.setFromSpherical( this._spherical ).applyQuaternion( this._yAxisUpSpaceInverse ),
 				1.0,
 			);
-
+		        const looktarget=this._camera.position.clone().sub(_v3A)
+			this._camera.lookAt(looktarget);
 		}
 
 		const updated = this._needsUpdate;


### PR DESCRIPTION
fix: Fixed an issue where when setting boundary and boundaryEncloseSComera to true, zooming back to the extreme position of the viewpoint with the mouse would result in incorrect looking direction of the camera, leading to errors in subsequent updates of the camera's cropping plane and causing some related calculation errors