### PR TITLE
Added PseudoElement to PseudoDocument Construcutor

### DIFF
--- a/examples/PseudoElement.js
+++ b/examples/PseudoElement.js
@@ -71,8 +71,10 @@ class PseudoDocument extends EventDispatcher {
 
 	/**
 	 * Creates an instance of PseudoDocument.
+  	 * @param {PseudoElement} pseudoElement
 	 */
-	constructor() {
+	constructor(pseudoElement) {
+		this.pseudoElement = pseudoElement;
 
 		super();
 
@@ -85,11 +87,11 @@ class PseudoDocument extends EventDispatcher {
 
 	/**
 	 * Just for compatibility. do nothing.
-	 * @returns {PseudoElement|null} The element locking the pointer.
+	 * @returns {PseudoElement} The element locking the pointer.
 	 */
 	get pointerLockElement() {
 
-		return null;
+		return this.pseudoElement;
 
 	}
 


### PR DESCRIPTION
Hey,

I just added the PseudoElement to the PseudoDocument constructor as requested [here](https://github.com/yomotsu/camera-controls/issues/569#issuecomment-2869865117) :) 
Hope this is useful for completing the worker example. My implementation was a bit hacky, you'll know better what to do, just as a reference, this is what I did (building on top of your worker example).

```js
// define extra pointer move event to be used when the pointer gets locked 
const onPointerMovePointerLock = (event: any) => {

  if (event.cancelable) event.preventDefault();
  
  const pseudoPointerEvent = {
    pointerId: event.pointerId,
    pointerType: event.pointerType,
    clientX: event.clientX,
    clientY: event.clientY,
    movementX: event.movementX,
    movementY: event.movementY,
    buttons: 1, // <- this tricks camera controls into thinking that the left mouse button is always down
  }
  
  postToWorker(port, "pointermove", pseudoPointerEvent);
}
```
```js
// on the main thread when toggling pointerlock on the chosen element (e.g. canvas):
// ...
const {onPointerMove, onPointerUp, onPointerMovePointerLock, onPointerDown} = callbacks;

const handlePointerLockChange = () => {
  // we exited pointer lock, re-bind the regular events
  if (document.pointerLockElement === null) {
    // remove the "locked" version of pointer move
    canvas.ownerDocument.removeEventListener('pointermove', onPointerMovePointerLock);
    // rebind the regular versions of pointer move combined with pointer up
    canvas.ownerDocument.addEventListener("pointermove", onPointerMove);
    canvas.ownerDocument.addEventListener('pointerup', onPointerUp);
    canvas.ownerDocument.addEventListener('pointerdown', onPointerDown);
  }
  // locking was successful, switch the events up
  else {
    // remove classical pointer events
    canvas.ownerDocument.removeEventListener('pointermove', onPointerMove);
    canvas.ownerDocument.removeEventListener('pointerup', onPointerUp);
    canvas.ownerDocument.removeEventListener('pointerdown', onPointerDown);
    // add the "locked" version of pointer move, tricking camera controls into thinking left mouse button is down
    canvas.ownerDocument.addEventListener('pointermove', onPointerMovePointerLock, {passive: false});
  }
}

```

The rest was pretty much the same as your worker example. I didn't make any changes on the worker side (except adding the `PseudoElement` to the `PseudoDocument` constructor.

Cheers

