### PR TITLE
feat: `cameraControls.lerp` position or spherical

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -38,7 +38,8 @@
 	<button onclick="cameraControls.normalizeRotations().setTarget( 3, 0, -3, true )">look at ( 3, 0, -3 )</button>
 	<button onclick="cameraControls.normalizeRotations().setLookAt( 1, 2, 3, 1, 1, 0, true )">move to ( 1, 2, 3 ), look at ( 1, 1, 0 )</button>
 	<br>
-	<button onclick="cameraControls.normalizeRotations().lerpLookAt( - 2, 0, 0, 1, 1, 0, 0, 2, 5, - 1, 0, 0, Math.random(), true )">move to somewhere between ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
+	<button onclick="cameraControls.normalizeRotations().lerp( { target: [1, 1, 0], position: [ - 2, 0, 0 ] }, { target: [ -1, 0, 0 ], position: [ 0, 2, 5]}, Math.random(), true )">move to somewhere between position/target: ( -2, 0, 0 ) -> ( 1, 1, 0 ) and ( 0, 2, 5 ) -> ( -1, 0, 0 )</button>
+	<button onclick="cameraControls.lerp( { target: [ 1, 1, 0 ], spherical: [ 2, 0, -Math.PI/2 ]}, { target: [ -1, 0, 0 ], spherical: [ 7, Math.PI, Math.PI/2 ]}, Math.random(), true )">move to somewhere inside a hemisphere of a radius ∈ [2..7] centered at a point located between ( 1, 1, 0 ) and ( -1, 0, 0 )</button>
 	<br>
 	<button onclick="cameraControls.normalizeRotations().reset( true )">reset</button>
 	<button onclick="cameraControls.saveState()">saveState</button>

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2189,7 +2189,6 @@ export class CameraControls extends EventDispatcher {
 	}
 
 	/**
-	 * @deprecated Use `lerp` instead
 	 * Similar to setLookAt, but it interpolates between two states.
 	 * @param positionAX
 	 * @param positionAY

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2124,7 +2124,7 @@ export class CameraControls extends EventDispatcher {
 		stateB: CameraControlsLerpState,
 		t: number,
 		enableTransition: boolean = false,
-	) {
+	): Promise<void> {
 
 		this._isUserControllingRotate = false;
 		this._isUserControllingDolly = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,3 +137,11 @@ export function isOrthographicCamera( camera: _THREE.Camera ): camera is _THREE.
 	return ( camera as _THREE.OrthographicCamera  ).isOrthographicCamera;
 
 }
+
+export type CameraControlsLerpState = {
+	target: [number, number, number]
+} & ( {
+	spherical: Parameters<_THREE.Spherical["set"]>
+} | {
+	position: [number, number, number]
+} );


### PR DESCRIPTION
a "general" `lerp()` method, between 2 states that can:
1. either includes: `(target,position)` -- like `lerpLookAt`
2. or: `(target,spherical)` -- NEW now with support for spherical values


```tsx
// 1.
cameraControls.lerp(
  {target: [1,0,0], position: [-2,0,0]}, // stateA
  {target: [-1,0,0], position: [0,2,5]}, // stateB
  .5,
  true
)

// 2.
cameraControls.lerp(
  {target: [0,0,0], spherical: [2,0,      -Math.PI/2]}, // stateA
  {target: [0,0,0], spherical: [7,Math.PI, Math.PI/2]}, // stateB
  //                               ^polar   ^azimuth
  //                            ^radius
  .5,
  true
)
```

illustration of `lerp` with spherical (2.):

|aligned targets|different targets|
|-|-|
|![shapes at 25-07-10 16 42 29](https://github.com/user-attachments/assets/b632dae3-8378-4e8a-9439-a539dceaadc5)|![shapes at 25-07-10 16 41 31](https://github.com/user-attachments/assets/c9dbe460-908d-4117-a706-99f8430f4441)|