### PR TITLE
fix: recreate pr-562 change

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2803,6 +2803,8 @@ export class CameraControls extends EventDispatcher {
 			! approxZero( this._focalOffset.z );
 		if ( affectOffset ) {
 
+			this._camera.matrix.compose( this._camera.position, this._camera.quaternion, this._camera.scale );
+
 			_xColumn.setFromMatrixColumn( this._camera.matrix, 0 );
 			_yColumn.setFromMatrixColumn( this._camera.matrix, 1 );
 			_zColumn.setFromMatrixColumn( this._camera.matrix, 2 );


### PR DESCRIPTION
@HTR1997 previously fixed the focal offset issue. However, as he mentioned here https://github.com/yomotsu/camera-controls/pull/562#issuecomment-2958262310, the change somehow disappeared, which has led to focal offset–related problems such as https://github.com/yomotsu/camera-controls/issues/605.

This PR restores @HTR1997’s fix and resolves the issues mentioned above.