### PR TITLE
Fix: pinching now zooms in and out instead of scrolling up/down.

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -767,11 +767,13 @@ export class CameraControls extends EventDispatcher {
 			// Ref: https://github.com/cedricpinson/osgjs/blob/00e5a7e9d9206c06fdde0436e1d62ab7cb5ce853/sources/osgViewer/input/source/InputSourceMouse.js#L89-L103
 			const deltaYFactor = isMac ? - 1 : - 3;
 			// Checks event.ctrlKey to detect multi-touch gestures on a trackpad.
-			const delta = ( event.deltaMode === 1 || event.ctrlKey ) ? event.deltaY / deltaYFactor : event.deltaY / ( deltaYFactor * 10 );
+			const delta = ( event.deltaMode === 1 && ! event.ctrlKey ) ? event.deltaY / deltaYFactor : event.deltaY / ( deltaYFactor * 10 );
 			const x = this.dollyToCursor ? ( event.clientX - this._elementRect.x ) / this._elementRect.width  *   2 - 1 : 0;
 			const y = this.dollyToCursor ? ( event.clientY - this._elementRect.y ) / this._elementRect.height * - 2 + 1 : 0;
 
-			switch ( this.mouseButtons.wheel ) {
+			// event.ctrlKey is set to true on macOS trackpad pinch gesture. In this case, always zoom.
+			const controlMode = event.ctrlKey ? ACTION.ZOOM : this.mouseButtons.wheel;
+			switch ( controlMode ) {
 
 				case ACTION.ROTATE: {
 


### PR DESCRIPTION
Fix for #604. Lets Apple trackpad users use the pinch gesture to zoom.

Zoom is triggered when ctrlKey is true. This happens both when pressing the CTRL key or when making a pinching gesture.

The zoom on Firefox has a different sensitivity than other browsers, so there was a condition (event.deltaMode == 0x01 [DOM_DELTA_LINE]) which helped set different sensitivities for different browsers. Firefox seems to be the only browser which sends 0x01 [DOM_DELTA_LINE], while the other ones send 0x00 [DOM_DELTA_PIXEL]. Source: https://stackoverflow.com/a/37474225

It seems that the sensitivity when pinching is *the same* across multiple browsers (I tested on Firefox, Chromium, and Safari), so I changed the condition to not change the sensitivity when pinching.

I tested the code by checking with the local examples, but also tested on a project of mine which uses React-Three-Drei, where one can truck in 2D and zoom. It worked well, and the same on all browsers (again, Firefox, Chromium and Safari).

I do not think documentation should be added, since this is an expected, intuitive and well-known behavior.