### PR TITLE
fix: wrap around transitions between azimuth angles close to ±180°

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,7 @@ See [the demo](https://github.com/yomotsu/camera-movement-comparison#dolly-vs-zo
 | `.colliderMeshes`         | `array`   | `[]`        | An array of Meshes to collide with camera ². |
 | `.infinityDolly`          | `boolean` | `false`     | `true` to enable Infinity Dolly for wheel and pinch. Use this with `minDistance` and `maxDistance` ³. |
 | `.restThreshold`          | `number`  | `0.0025`    | Controls how soon the `rest` event fires as the camera slows |
+| `.smoothRotationTheta`    | `boolean` | `true`      | `true` to smooth azimuth (`theta`) transitions along the shortest path (wraps angles such as -179° ↔ 179°). |
 
 1. Every 360 degrees turn is added to `.azimuthAngle` value, which is accumulative.  
   `360º = 360 * THREE.MathUtils.DEG2RAD = Math.PI * 2`, `720º = Math.PI * 4`.  
@@ -658,6 +659,8 @@ Set current camera position as the default position
 
 Normalize camera azimuth angle (horizontal rotation) between -180 and 180 degrees.
 This is useful when you want to keep the azimuth angle normalized before calling methods like `.setLookAt()`, `.lerpLookAt()`, `.setTarget()`, `.setPosition()`, and `.reset()`.
+
+When combined with the `.smoothRotationTheta` property (enabled by default), theta transitions always follow the shortest rotational path during smoothing.
 
 This method returns the CameraControls instance itself, so you can chain it with other methods.
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -297,6 +297,13 @@ export class CameraControls extends EventDispatcher {
 	restThreshold = 0.01;
 
 	/**
+	 * `true` to enable smooth rotation interpolation along the shortest path for azimuth (theta).
+	 * When enabled, rotating between angles like -179° and 179° will take the short 2° path instead of rotating 358°.
+	 * @category Properties
+	 */
+	smoothRotationTheta = true;
+
+	/**
 	 * An array of Meshes to collide with camera.  
 	 * Be aware colliderMeshes may decrease performance. The collision test uses 4 raycasters from the camera since the near plane has 4 corners.
 	 * @category Properties
@@ -2619,7 +2626,7 @@ export class CameraControls extends EventDispatcher {
 		} else {
 
 			const smoothTime = this._isUserControllingRotate ? this.draggingSmoothTime : this.smoothTime;
-			this._spherical.theta = smoothDamp( this._spherical.theta, this._sphericalEnd.theta, this._thetaVelocity, smoothTime, Infinity, delta );
+			this._spherical.theta = smoothDamp( this._spherical.theta, this._sphericalEnd.theta, this._thetaVelocity, smoothTime, Infinity, delta, this.smoothRotationTheta ? 'shortestAngle' : 'none' );
 			this._needsUpdate = true;
 
 		}


### PR DESCRIPTION
### Summary

- Extend `smoothDamp` with an optional `shortestAngle` wrap mode so theta easing can interpolate across ±π without swinging the long way.
- Add a `smoothRotationTheta` property (default true) that opts azimuth damping into the shortest-path behavior while leaving an escape hatch for legacy workflows.
- Document the new option and call out how it pairs with `normalizeAzimuthAngle()` for predictable wrap handling.

### Context

Previously, any smoothed azimuth transition that crossed the ±180° boundary could trigger a ~360° spin; this was especially noticeable when snapping between near-opposite headings. With the new wrap logic we always take the minimal rotational delta, yielding the expected short 2–3° ease.