### PR TITLE
stabilize near zero values to avoid jumping between 0 and 180 degrees

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2091,7 +2091,17 @@ export class CameraControls extends EventDispatcher {
 		const position = _v3A.set( positionX, positionY, positionZ );
 
 		this._targetEnd.copy( target );
-		this._sphericalEnd.setFromVector3( position.sub( target ).applyQuaternion( this._yAxisUpSpace ) );
+		position.sub(target)
+		if(approxZero(position.x)) {
+			position.x = 0;
+		}
+		if(approxZero(position.y)) {
+			position.y = 0;
+		}
+		if(approxZero(position.z)) {
+			position.z = 0;
+		}
+		this._sphericalEnd.setFromVector3( position.applyQuaternion( this._yAxisUpSpace ) );
 
 		this._needsUpdate = true;
 


### PR DESCRIPTION
I've run into a situation where I'm continuously persisting camera location values and reloading them into the camera controls. There are tiny floating point errors that cause huge jumps in the orientation of the camera. When I scroll to zoom, I see the camera flip between 0 and 180 degrees. This PR stabilizes near zero values at 0 to avoid this issue.

Here is a minimal example that shows the problem that this PR fixes:
```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Camera Controls Instability Test</title>
    <style>
        body { margin: 0; overflow: hidden; font-family: monospace; }
        canvas { display: block; }
    </style>
</head>
<body>
    <script type="importmap">
    {
        "imports": {
            "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
            "camera-controls": "https://cdn.jsdelivr.net/npm/camera-controls@2.9.0/dist/camera-controls.module.js"
        }
    }
    </script>

    <script type="module">
        import * as THREE from 'three';
        import CameraControls from 'camera-controls';

        CameraControls.install({ THREE });

        // Setup
        const scene = new THREE.Scene();
        const aspect = window.innerWidth / window.innerHeight;
        const frustumSize = 20;
        const camera = new THREE.OrthographicCamera(
          frustumSize * aspect / -2,
          frustumSize * aspect / 2,
          frustumSize / 2,
          frustumSize / -2,
          0.1,
          1000
        );
        camera.up.set(0, 0, 1);
        camera.updateProjectionMatrix();

        const renderer = new THREE.WebGLRenderer({ antialias: true });
        renderer.setSize(window.innerWidth, window.innerHeight);
        document.body.appendChild(renderer.domElement);

        // Add axes helper to visualize orientation
        const axesHelper = new THREE.AxesHelper(5);
        scene.add(axesHelper);

        const geometry = new THREE.BoxGeometry(2, 2, 2);
        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
        const cube = new THREE.Mesh(geometry, material);
        scene.add(cube);

        // Camera controls
        const controls = new CameraControls(camera, renderer.domElement);
        controls.setPosition(4.399999500000001, -3.2499995, 12.025501499999999);
        controls.setTarget(4.399999500000001, -3.2499995, -1.1745);
        controls.zoomTo(80, true)

        let savedCameraState = {
            position: [4.399999500000001, -3.249999499999998, 12.02550149999995],
            target: [4.399999500000001, -3.2499995, -1.1745],
            zoom: 80
        };

        let prevZoom = camera.zoom;

        function saveCameraPosition() {
            const position = new THREE.Vector3();
            const target = new THREE.Vector3();
            controls.getPosition(position);
            controls.getTarget(target);

            const newState = {
                position: position.toArray(),
                target: target.toArray(),
                zoom: camera.zoom
            };

            savedCameraState = newState;
            updateCameraFromState();
        }

        function updateCameraFromState() {
          controls.setLookAt(
              savedCameraState.position[0],
              savedCameraState.position[1],
              savedCameraState.position[2],
              savedCameraState.target[0],
              savedCameraState.target[1],
              savedCameraState.target[2],
              false  // enableTransition = false
          );

          controls.zoomTo(savedCameraState.zoom, false);
        }

        function animate() {
            requestAnimationFrame(animate);

            if (Math.abs(camera.zoom - prevZoom) > 1e-10) {
                saveCameraPosition();
                prevZoom = camera.zoom;
            }

            controls.update(0.016); // ~60fps
            renderer.render(scene, camera);
        }

        animate();

        // Handle window resize
        window.addEventListener('resize', () => {
          const aspect = window.innerWidth / window.innerHeight;
          camera.left = frustumSize * aspect / -2;
          camera.right = frustumSize * aspect / 2;
          camera.top = frustumSize / 2;
          camera.bottom = frustumSize / -2;
          camera.updateProjectionMatrix();
          renderer.setSize(window.innerWidth, window.innerHeight);
        });
    </script>
</body>
</html>

```