### PR TITLE
Fix: Implement shortest arc theta interpolation in `update()`

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2624,7 +2624,7 @@ export class CameraControls extends EventDispatcher {
 
 			const TAU = Math.PI * 2;
 			diff = ( ( diff % TAU ) + TAU ) % TAU; // normalise to [0, TAU)
-			if ( diff > Math.PI ) diff -= TAU;   // shift to [-PI, PI)
+			if ( diff > Math.PI ) diff -= TAU;     // shift to [-PI, PI)
 
 			const shortestArcTheta = this._sphericalEnd.theta - diff;
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2620,9 +2620,20 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
+			let diff = this._sphericalEnd.theta - this._spherical.theta;
+
+			const TAU = Math.PI * 2;
+			diff = ( ( diff % TAU ) + TAU ) % TAU; // normalise to [0, TAU)
+			if ( diff > Math.PI ) diff -= TAU;   // shift to [-PI, PI)
+
+			const shortestArcTheta = this._sphericalEnd.theta - diff;
+
 			const smoothTime = this._isUserControllingRotate ? this.draggingSmoothTime : this.smoothTime;
-			this._spherical.theta = smoothDamp( this._spherical.theta, this._sphericalEnd.theta, this._thetaVelocity, smoothTime, Infinity, delta );
+			this._spherical.theta = smoothDamp( shortestArcTheta, this._sphericalEnd.theta, this._thetaVelocity, smoothTime, Infinity, delta );
 			this._needsUpdate = true;
+
+			// normalize theta to prevent overflow
+			this._spherical.theta = this._spherical.theta % ( Math.PI * 2 );
 
 		}
 


### PR DESCRIPTION
Hi, I noticed that when calling `setLookAt(..., enableTransition: true)`, it would sometimes interpolate a full circle when going from 360deg to 361deg, instead of interpolating by 1deg.

In this PR I have implemented shortest arc theta interpolation instead of the previously implemented linear interpolation.