### PR TITLE
use camera's parent to transform target into world space

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2796,7 +2796,15 @@ export class CameraControls extends EventDispatcher {
 		// decompose spherical to the camera position
 		this._spherical.makeSafe();
 		this._camera.position.setFromSpherical( this._spherical ).applyQuaternion( this._yAxisUpSpaceInverse ).add( this._target );
-		this._camera.lookAt( this._target );
+
+		_v3A.copy( this._target );
+		if ( this._camera.parent ) {
+
+			this._camera.parent.localToWorld( _v3A );
+
+		}
+
+		this._camera.lookAt( _v3A );
 
 		// set offset after the orbit movement
 		const affectOffset =


### PR DESCRIPTION
Currently, if the camera is parented to a moving object, the orientation of the camera will change with it because the camera.lookAt function is used to orient the camera. The camera target should be transformed into world space first to allow for the camera to be parented to an object. This pull request performs this transformation.