### PR TITLE
chore(security): harden release workflow and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Keep GitHub-owned actions pinned by SHA in .github/workflows/release.yml
+  # up to date with weekly patch bumps. Dependabot opens a PR when an action
+  # releases a new tag within the currently-used major version.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default token scopes: read-only. Jobs that need to write (release, pages) opt in explicitly.
+permissions:
+  contents: read
+
 jobs:
 
   release-job:
     runs-on: ubuntu-latest
+    permissions:
+      # semantic-release needs these to create the GitHub release, push tags,
+      # and post release-note comments on referenced issues/PRs.
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -44,13 +44,13 @@ jobs:
         run: npm run typedoc
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: typedoc-docs
           path: docs/
@@ -67,18 +67,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
 
       - name: Download typedoc docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: typedoc-docs
           path: docs/
@@ -104,14 +104,14 @@ jobs:
           find docs -type l -delete
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           name: github-pages
           path: ./docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest published release on the `main` branch receives security fixes. Please keep dependencies up to date; older versions will not be patched.
+
+| Version | Supported |
+|---|---|
+| Latest published on `main` | Yes |
+| Older versions | No |
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately via [GitHub's private vulnerability reporting](https://github.com/yomotsu/camera-controls/security/advisories/new) rather than opening a public issue.
+
+When reporting, please include:
+
+- A description of the issue
+- Steps to reproduce, or a minimal proof-of-concept
+- The affected version(s)
+- Any known mitigation or workaround
+
+You should receive an acknowledgement within a reasonable time. Please do not disclose the issue publicly until a fix has been released.


### PR DESCRIPTION
## Summary

This PR is a small, security-only hardening pass on the `release.yml` workflow, plus a Dependabot config so the pins do not go stale, plus a minimal `SECURITY.md`. No behavioral or version changes to the release pipeline; everything keeps working exactly as today.

Motivation is the [OpenSSF Scorecard report](https://api.securityscorecards.dev/projects/github.com/yomotsu/camera-controls) for this repo, which currently scores **2.9/10**. Scorecard is used by downstream consumers to assess dependency supply-chain risk, and a few of its checks can be satisfied with very small edits here.

## Changes

### 1. Pin GitHub-owned actions by commit SHA

Scorecard's `Pinned-Dependencies` check currently flags every `uses:` line in [`.github/workflows/release.yml`](.github/workflows/release.yml) because they reference floating major tags (`@v4`, `@v5`, `@v3`) which can be force-repointed by the action owner without any change visible here. This is the standard supply-chain concern that led to, e.g., the `tj-actions/changed-files` incident.

I pinned each action to the **latest SHA within the currently-declared major version**, so behavior is identical to what the workflow does today, with a trailing version comment for readability:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2` |
| `actions/download-artifact` | `@v4` | `@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0` |
| `actions/configure-pages` | `@v5` | `@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0` |
| `actions/upload-pages-artifact` | `@v3` | `@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1` |
| `actions/deploy-pages` | `@v4` | `@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5` |

This is the same transformation the [StepSecurity secure-workflow helper](https://app.stepsecurity.io/secureworkflow/yomotsu/camera-controls/release.yml/dev?enable=pin) produces.

### 2. Restrict `GITHUB_TOKEN` permissions (principle of least privilege)

Scorecard's `Token-Permissions` check currently flags the workflow because there is no top-level `permissions:` block, so every job inherits the repository's default token scopes (often broad write).

I added:

- **Top-level default**: `permissions: contents: read` (read-only fallback for any step that doesn't opt into more).
- **`release-job` override**: `contents: write`, `issues: write`, `pull-requests: write` — the minimum set required by `semantic-release`'s default plugins. `@semantic-release/github` needs `contents: write` to create the GitHub release and push tags, and it needs `issues: write` plus `pull-requests: write` to post release-note comments on the issues/PRs referenced in the commit range.
- **`deploy-job`**: unchanged (`contents: read`, `pages: write`, `id-token: write` are already declared at job level, which is correct).

### 3. Add Dependabot config for GitHub Actions

A new [`.github/dependabot.yml`](.github/dependabot.yml) with a weekly schedule for the `github-actions` ecosystem ensures pinned SHAs get bumped automatically when actions ship security fixes or new patches, rather than drifting silently. Without this, SHA-pinning turns into a maintenance burden.

If Dependabot is disabled at the org/repo level the file is a no-op and has no effect on anything; it just sits there.

### 4. Add `SECURITY.md`

A minimal security policy declaring the supported version line and the reporting channel (GitHub private vulnerability reporting). This satisfies Scorecard's `Security-Policy` check and gives downstream security teams a documented place to send reports.

## Scorecard effect (projection)

| Check | Before | After (projection) |
|---|---:|---:|
| Pinned-Dependencies | 0 | 10 |
| Token-Permissions | 0 | 10 |
| Security-Policy | 0 | 10 |
| Others | unchanged | unchanged |

Overall score projection: ~2.9 -> ~5.5-6.0.

A companion issue will be filed for the only remaining Scorecard check that can't be addressed via a PR — branch protection — since that is a repository settings change only a maintainer can make.

## Commits

Four atomic commits so each change is independently reviewable. Happy to squash on merge if preferred.

1. `chore(security): pin GitHub Actions by SHA in release.yml`
2. `chore(security): restrict GITHUB_TOKEN permissions to least privilege`
3. `chore: add Dependabot config for github-actions ecosystem`
4. `docs: add SECURITY.md`

## Testing

- No functional change to the release pipeline. The workflow triggers only on push to `main`, so no CI runs on this `dev`-targeted PR; the workflow diff can be verified by reading `release.yml` directly.
- The pinned SHAs have been cross-checked against the official action repositories' tag refs (via the GitHub API) to confirm they resolve to the upstream tag objects for the respective version lines.
- `semantic-release` permissions are set per the official [`@semantic-release/github` docs](https://github.com/semantic-release/github#github-authentication).

## References

- [OpenSSF Scorecard — yomotsu/camera-controls](https://api.securityscorecards.dev/projects/github.com/yomotsu/camera-controls)
- [Scorecard Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
- [Scorecard Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
- [Scorecard Security-Policy check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy)
- Companion issue: #631 (branch protection, maintainer-only)

Made with [Cursor](https://cursor.com)