### PR TITLE
 feat: per-operation smoothTime config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@typescript-eslint/eslint-plugin": "^8.36.0",
         "@typescript-eslint/parser": "^8.36.0",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "downlevel-dts": "^0.11.0",
         "eslint": "^9.31.0",
         "globals": "^16.3.0",
         "husky": "^9.1.7",
@@ -34,8 +33,8 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=20.11.0",
-        "npm": ">=10.8.2"
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
       },
       "peerDependencies": {
         "three": ">=0.126.1"
@@ -3220,20 +3219,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/downlevel-dts": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.11.0.tgz",
-      "integrity": "sha512-vo835pntK7kzYStk7xUHDifiYJvXxVhUapt85uk2AI94gUUAQX9HNRtrcMHNSc3YHJUEHGbYIGsM99uIbgAtxw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.3",
-        "typescript": "next"
-      },
-      "bin": {
-        "downlevel-dts": "index.js"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3978,12 +3963,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4158,27 +4137,6 @@
         "through2": "~2.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4189,29 +4147,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -4596,17 +4531,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4631,15 +4555,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/into-stream": {
@@ -8800,15 +8715,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -9045,15 +8951,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-is-inside": {
@@ -9455,18 +9352,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -10192,23 +10077,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -11465,12 +11333,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
     "conventional-changelog-conventionalcommits": "^9.1.0",
-    "downlevel-dts": "^0.11.0",
     "eslint": "^9.31.0",
     "globals": "^16.3.0",
     "husky": "^9.1.7",
@@ -52,7 +51,7 @@
     "dev:rollup": "rollup --config --watch",
     "dev:serve": "serve -S -p 3000 ./ && kill $!",
     "dev:open": "open-cli http://localhost:3000/examples/",
-    "build": "rollup --config && terser dist/camera-controls.module.js -o dist/camera-controls.module.min.js --comments '/^!/' && downlevel-dts . .",
+    "build": "rollup --config && terser dist/camera-controls.module.js -o dist/camera-controls.module.min.js --comments '/^!/'",
     "prepack": "npm run build",
     "lint": "eslint src",
     "typedoc": "typedoc",
@@ -63,13 +62,6 @@
     "last 3 versions",
     "not dead"
   ],
-  "typesVersions": {
-    "<=3.4.0-0": {
-      "*": [
-        "./"
-      ]
-    }
-  },
   "keywords": [
     "three",
     "three.js",

--- a/readme.md
+++ b/readme.md
@@ -171,8 +171,8 @@ See [the demo](https://github.com/yomotsu/camera-movement-comparison#dolly-vs-zo
 | `.maxAzimuthAngle`        | `number`  | `Infinity`  | In radians. |
 | `.boundaryFriction`       | `number`  | `0.0`       | Friction ratio of the boundary. |
 | `.boundaryEnclosesCamera` | `boolean` | `false`     | Whether camera position should be enclosed in the boundary or not. |
-| `.smoothTime`             | `number`  | `0.25`      | Approximate time in seconds to reach the target. A smaller value will reach the target faster. |
-| `.draggingSmoothTime`     | `number`  | `0.125`     | The smoothTime while dragging. |
+| `.smoothTime`             | `number \| object` | `0.25`  | Approximate time in seconds to reach the target. A smaller value will reach the target faster. A number applies to all operations, or pass an object keyed by `rotate` / `truck` / `dolly` / `zoom` / `offset`. |
+| `.controlSmoothTime`      | `number \| object` | `0.125` | The smoothTime used while the user is actively controlling the camera. Same number-or-object form as `.smoothTime`. |
 | `.azimuthRotateSpeed`     | `number`  | `1.0`       | Speed of azimuth rotation. |
 | `.polarRotateSpeed`       | `number`  | `1.0`       | Speed of polar rotation. |
 | `.dollySpeed`             | `number`  | `1.0`       | Speed of mouse-wheel dollying. |
@@ -823,6 +823,19 @@ cameraControls.normalizeRotations().setLookAt( 0, 0, 5, 0, 0, 0, true ); // v3
 ```
 
 The angle range for `normalizeRotations()` has been changed from 0deg to 360deg to -180deg to 180deg.
+
+### Granular smooth time
+
+`.smoothTime` and `.controlSmoothTime` now accept either a `number` (applied to every operation) or an object keyed by operation — `rotate`, `truck`, `dolly`, `zoom`, `offset`:
+
+```js
+cameraControls.smoothTime = 0.25;           // all operations
+cameraControls.smoothTime = { dolly: 0.1 }; // only dolly; the other operations keep their current values
+```
+
+- **Breaking:** reading `.smoothTime` / `.controlSmoothTime` now returns an object (`{ rotate, truck, dolly, zoom, offset }`) instead of a `number`.
+- `.draggingSmoothTime` is renamed to `.controlSmoothTime`. The old name still works as a deprecated alias.
+- The published type declarations are no longer downleveled (TypeScript >= 4.3 is now required to consume the types).
 
 ## V2 Migration Guide
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2,6 +2,8 @@ import type * as _THREE from 'three';
 import {
 	THREESubset,
 	Ref,
+	SmoothTimes,
+	SmoothTimeOption,
 	MOUSE_BUTTON,
 	ACTION,
 	DOLLY_DIRECTION,
@@ -35,6 +37,7 @@ import { EventDispatcher, Listener } from './EventDispatcher';
 
 const VERSION = '__VERSION'; // will be replaced with `version` in package.json during the build process.
 const TOUCH_DOLLY_FACTOR = 1 / 8;
+const SMOOTH_TIME_KEYS: ( keyof SmoothTimes )[] = [ 'rotate', 'truck', 'dolly', 'zoom', 'offset' ];
 const isMac = /Mac/.test( globalThis?.navigator?.platform );
 
 let THREE: THREESubset;
@@ -226,18 +229,6 @@ export class CameraControls extends EventDispatcher {
 	 * @category Properties
 	 */
 	maxZoom = Infinity;
-
-	/**
-	 * Approximate time in seconds to reach the target. A smaller value will reach the target faster.
-	 * @category Properties
-	 */
-	smoothTime = 0.25;
-
-	/**
-	 * the smoothTime while dragging
-	 * @category Properties
-	 */
-	draggingSmoothTime = 0.125;
 
 	/**
 	 * Max transition speed in unit-per-seconds
@@ -434,6 +425,10 @@ export class CameraControls extends EventDispatcher {
 	protected _focalOffsetVelocity: _THREE.Vector3 = new THREE.Vector3();
 	protected _zoomVelocity: Ref = { value: 0 };
 
+	// per-operation smooth times; populated via the setters in the constructor.
+	protected _smoothTime = {} as SmoothTimes;
+	protected _controlSmoothTime = {} as SmoothTimes;
+
 	/**
 	 * @deprecated Use `cameraControls.mouseButtons.left = CameraControls.ACTION.SCREEN_PAN` instead.
 	 */
@@ -478,6 +473,10 @@ export class CameraControls extends EventDispatcher {
 		this._yAxisUpSpace = new THREE.Quaternion().setFromUnitVectors( this._camera.up, _AXIS_Y );
 		this._yAxisUpSpaceInverse = this._yAxisUpSpace.clone().invert();
 		this._state = ACTION.NONE;
+
+		// fills every per-operation key via the setters' number branch
+		this.smoothTime = 0.25;
+		this.controlSmoothTime = 0.125;
 
 		// the location
 		this._target = new THREE.Vector3();
@@ -2647,7 +2646,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingRotate ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingRotate ? this._controlSmoothTime.rotate : this._smoothTime.rotate;
 			this._spherical.theta = smoothDamp( this._spherical.theta, this._sphericalEnd.theta, this._thetaVelocity, smoothTime, Infinity, delta );
 			this._needsUpdate = true;
 
@@ -2661,7 +2660,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingRotate ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingRotate ? this._controlSmoothTime.rotate : this._smoothTime.rotate;
 			this._spherical.phi = smoothDamp( this._spherical.phi, this._sphericalEnd.phi, this._phiVelocity, smoothTime, Infinity, delta );
 			this._needsUpdate = true;
 
@@ -2675,7 +2674,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingDolly ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingDolly ? this._controlSmoothTime.dolly : this._smoothTime.dolly;
 			this._spherical.radius = smoothDamp( this._spherical.radius, this._sphericalEnd.radius, this._radiusVelocity, smoothTime, this.maxSpeed, delta );
 			this._needsUpdate = true;
 
@@ -2689,7 +2688,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingTruck ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingTruck ? this._controlSmoothTime.truck : this._smoothTime.truck;
 			smoothDampVec3( this._target, this._targetEnd, this._targetVelocity, smoothTime, this.maxSpeed, delta, this._target );
 			this._needsUpdate = true;
 
@@ -2703,7 +2702,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingOffset ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingOffset ? this._controlSmoothTime.offset : this._smoothTime.offset;
 			smoothDampVec3( this._focalOffset, this._focalOffsetEnd, this._focalOffsetVelocity, smoothTime, this.maxSpeed, delta, this._focalOffset );
 			this._needsUpdate = true;
 
@@ -2717,7 +2716,7 @@ export class CameraControls extends EventDispatcher {
 
 		} else {
 
-			const smoothTime = this._isUserControllingZoom ? this.draggingSmoothTime : this.smoothTime;
+			const smoothTime = this._isUserControllingZoom ? this._controlSmoothTime.zoom : this._smoothTime.zoom;
 			this._zoom = smoothDamp( this._zoom, this._zoomEnd, this._zoomVelocity, smoothTime, Infinity, delta );
 
 		}
@@ -2929,8 +2928,8 @@ export class CameraControls extends EventDispatcher {
 			maxPolarAngle        : infinityToMaxNumber( this.maxPolarAngle ),
 			minAzimuthAngle      : infinityToMaxNumber( this.minAzimuthAngle ),
 			maxAzimuthAngle      : infinityToMaxNumber( this.maxAzimuthAngle ),
-			smoothTime           : this.smoothTime,
-			draggingSmoothTime   : this.draggingSmoothTime,
+			smoothTime           : this._smoothTime,
+			controlSmoothTime    : this._controlSmoothTime,
 			dollySpeed           : this.dollySpeed,
 			truckSpeed           : this.truckSpeed,
 			dollyToCursor        : this.dollyToCursor,
@@ -2970,7 +2969,7 @@ export class CameraControls extends EventDispatcher {
 		this.minAzimuthAngle       = maxNumberToInfinity( obj.minAzimuthAngle );
 		this.maxAzimuthAngle       = maxNumberToInfinity( obj.maxAzimuthAngle );
 		this.smoothTime            = obj.smoothTime;
-		this.draggingSmoothTime    = obj.draggingSmoothTime;
+		this.controlSmoothTime     = obj.controlSmoothTime;
 		this.dollySpeed            = obj.dollySpeed;
 		this.truckSpeed            = obj.truckSpeed;
 		this.dollyToCursor         = obj.dollyToCursor;
@@ -3356,6 +3355,77 @@ export class CameraControls extends EventDispatcher {
 	protected _removeAllEventListeners(): void {}
 
 	/**
+	 * Approximate time in seconds to reach the target. A smaller value will reach the target faster.
+	 * Accepts a number (applied to every operation) or an object keyed by operation
+	 * (`rotate`, `truck`, `dolly`, `zoom`, `offset`); an object merges the given keys.
+	 * @category Properties
+	 */
+	get smoothTime(): SmoothTimes {
+
+		return this._smoothTime;
+
+	}
+	set smoothTime( value: SmoothTimeOption ) {
+
+		this._applySmoothTime( this._smoothTime, value );
+
+	}
+
+	/**
+	 * The smoothTime used while the user is actively controlling the camera (overrides
+	 * `smoothTime` per operation). Accepts a number or an object keyed by operation.
+	 * @category Properties
+	 */
+	get controlSmoothTime(): SmoothTimes {
+
+		return this._controlSmoothTime;
+
+	}
+	set controlSmoothTime( value: SmoothTimeOption ) {
+
+		this._applySmoothTime( this._controlSmoothTime, value );
+
+	}
+
+	/**
+	 * backward compatible
+	 * @deprecated use controlSmoothTime instead
+	 * @category Properties
+	 */
+	get draggingSmoothTime(): SmoothTimes {
+
+		console.warn( '.draggingSmoothTime has been deprecated. use controlSmoothTime instead.' );
+		return this._controlSmoothTime;
+
+	}
+	set draggingSmoothTime( value: SmoothTimeOption ) {
+
+		console.warn( '.draggingSmoothTime has been deprecated. use controlSmoothTime instead.' );
+		this._applySmoothTime( this._controlSmoothTime, value );
+
+	}
+
+	protected _applySmoothTime( target: SmoothTimes, value: SmoothTimeOption ): void {
+
+		if ( value == null ) return;
+
+		if ( typeof value === 'number' ) {
+
+			target.rotate = target.truck = target.dolly = target.zoom = target.offset = value;
+
+		} else {
+
+			for ( const key of SMOOTH_TIME_KEYS ) {
+
+				if ( value[ key ] !== undefined ) target[ key ] = value[ key ]!;
+
+			}
+
+		}
+
+	}
+
+	/**
 	 * backward compatible
 	 * @deprecated use smoothTime (in seconds) instead
 	 * @category Properties
@@ -3380,24 +3450,24 @@ export class CameraControls extends EventDispatcher {
 
 	/**
 	 * backward compatible
-	 * @deprecated use draggingSmoothTime (in seconds) instead
+	 * @deprecated use controlSmoothTime (in seconds) instead
 	 * @category Properties
 	 */
 	get draggingDampingFactor() {
 
-		console.warn( '.draggingDampingFactor has been deprecated. use draggingSmoothTime (in seconds) instead.' );
+		console.warn( '.draggingDampingFactor has been deprecated. use controlSmoothTime (in seconds) instead.' );
 		return 0;
 
 	}
 
 	/**
 	 * backward compatible
-	 * @deprecated use draggingSmoothTime (in seconds) instead
+	 * @deprecated use controlSmoothTime (in seconds) instead
 	 * @category Properties
 	 */
 	set draggingDampingFactor( _: number ) {
 
-		console.warn( '.draggingDampingFactor has been deprecated. use draggingSmoothTime (in seconds) instead.' );
+		console.warn( '.draggingDampingFactor has been deprecated. use controlSmoothTime (in seconds) instead.' );
 
 	}
 

--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -3398,6 +3398,11 @@ export class CameraControls extends EventDispatcher {
 		return this._controlSmoothTime;
 
 	}
+	/**
+	 * backward compatible
+	 * @deprecated use controlSmoothTime instead
+	 * @category Properties
+	 */
 	set draggingSmoothTime( value: SmoothTimeOption ) {
 
 		console.warn( '.draggingSmoothTime has been deprecated. use controlSmoothTime instead.' );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { CameraControls as default } from './CameraControls';
 export { EventDispatcher } from './EventDispatcher';
+export type { SmoothTimes, SmoothTimeOption } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,16 @@ export type Ref = {
 	value: number;
 }
 
+export interface SmoothTimes {
+	rotate: number;
+	truck: number;
+	dolly: number;
+	zoom: number;
+	offset: number;
+}
+
+export type SmoothTimeOption = number | Partial<SmoothTimes>;
+
 // see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons#value
 export const MOUSE_BUTTON = {
 	LEFT: 1,


### PR DESCRIPTION
Fixes #619 

## Summary

`smoothTime` and `controlSmoothTime` (renamed from `draggingSmoothTime`) can now be
configured per camera operation, instead of a single value for everything.

Both accept either a `number` (applied to all operations) or an object keyed by
operation — `rotate`, `truck`, `dolly`, `zoom`, `offset`:

```js
controls.smoothTime = 0.25;                 // all operations (unchanged behavior)
controls.smoothTime = { dolly: 0.1 };       // only dolly; other operations keep their current values
controls.controlSmoothTime = { rotate: 0.05 };
```

`controlSmoothTime` overrides `smoothTime` per operation while the user is actively
controlling the camera (any input — drag, wheel, touch, trackpad pinch), keyed off
the existing `_isUserControlling*` flags.

Setting a number fills all keys; setting an object merges only the provided keys
(others keep their current value). The getter returns the live normalized object,
so `controls.smoothTime.dolly = 0.1` also works.

### Breaking changes

- Reading `smoothTime` / `controlSmoothTime` now returns an object
(`{ rotate, truck, dolly, zoom, offset }`) instead of a number. Assignment is
unchanged for the common = 0.25 case.
- `draggingSmoothTime` is renamed to `controlSmoothTime`. The old name remains
as a deprecated alias (warns, proxies to `controlSmoothTime`).
- Type declarations now require TypeScript >= 4.3 (see below).

### Removing downlevel-dts

This PR drops the downlevel-dts build step (and the typesVersions: { "<=3.4.0-0" }
entry).

downlevel-dts was added years ago (#70) for an Angular 8 / TypeScript ≤ 3.5
consumer that couldn't handle get/set accessors in declaration files — a limitation
TypeScript lifted in 3.6 (2019).

In this repo it ran as `downlevel-dts . .`, which overwrites dist/index.d.ts in
place with the TS-3.4 form. That single file is what types / exports.types
points to, so every consumer — not just old TypeScript — received the downleveled
output, with get/set accessors flattened into plain properties. (The <=3.4
typesVersions redirect pointed at the package root, where the build produced no
index.d.ts, so it was effectively dead config.)

This was lossless until now, because every existing accessor had matching
getter/setter types. This PR introduces the first accessor with different
get/set types (get smoothTime(): SmoothTimes / set smoothTime(value: SmoothTimeOption)).
Flattening collapses that to smoothTime: SmoothTimes, which makes controls.smoothTime = 0.25
a type error for consumers even though it works at runtime.

Supporting different-typed accessors requires TypeScript 4.3+ (2021). Given TS 3.4
is from 2019 and the original Angular 8 consumer is long EOL, dropping the downlevel
step is the cleanest fix: modern, accurate accessor types now ship directly to all
consumers. The only affected audience is anyone still on TS < 4.3.