### PR TITLE
fix: emit missed 'rest' before 'sleep' so transition listeners can't leak

### DIFF
--- a/src/CameraControls.ts
+++ b/src/CameraControls.ts
@@ -2898,7 +2898,26 @@ export class CameraControls extends EventDispatcher {
 
 		} else if ( ! updated && this._updatedLastTime ) {
 
-			this.dispatchEvent( { type: 'sleep' } );
+			// A transition can stop without `update()` ever observing a settling
+			// frame — e.g. `smoothTime` 0, where each move converges in the same
+			// frame it starts — so the `rest` owed to `_createOnRestPromise()`
+			// listeners is never emitted and they accumulate unbounded. Emit it
+			// here before sleeping; the `_hasRested` guard keeps it a no-op once
+			// `rest` has already fired the usual way.
+			if ( ! this._hasRested ) {
+
+				this._hasRested = true;
+				this.dispatchEvent( { type: 'rest' } );
+
+			}
+
+			// A `rest` handler may have started a new transition; only sleep when
+			// nothing is pending, so `sleep` never fires while the camera moves.
+			if ( ! this._needsUpdate ) {
+
+				this.dispatchEvent( { type: 'sleep' } );
+
+			}
 
 		}
 


### PR DESCRIPTION
## The bug

`update()` dispatches `rest` only from the `else if ( updated )` branch — i.e. when the deltas fall within `restThreshold` **while the camera is still animating**. If the camera instead converges in the same frame a move starts, the next frame is not updated, so `update()` takes the `! updated && this._updatedLastTime` branch straight to `sleep` and skips `rest` entirely.

This is easiest to hit with `smoothTime = 0` (each move settles in the frame it starts), but any move small enough to settle within a single frame reaches it too.

Every transition-enabled call — `rotate` / `dolly` / `truck` / … , e.g. one per `pointermove` during a drag — registers a `rest` listener via `_createOnRestPromise()` that only detaches when `rest` fires. When `rest` is never emitted, those listeners, plus their promises and the closures they capture, accumulate **unbounded** for the life of the controls. A continuous drag under `smoothTime = 0` leaks one listener set per pointer-move.

We found this as the dominant retained-heap growth in a `three` app (heap snapshots showed one extra `Promise` + `onResolve` closure per pointer-move, surviving major GC).

## The fix

Emit the owed `rest` in the `sleep` branch, guarded on `! this._hasRested` so it is a strict no-op once `rest` has already fired the normal way. `sleep` already implies the camera has come to rest, so emitting the missing `rest` first is also more consistent with the documented event order (`rest` before `sleep`).

Because a `rest` listener may synchronously start a new transition, the `sleep` dispatch is also guarded on `! this._needsUpdate` — so `sleep` never fires in the same frame a `rest` handler kicked off new movement (the next frame emits `wake` as usual).

```ts
} else if ( ! updated && this._updatedLastTime ) {

    if ( ! this._hasRested ) {

        this._hasRested = true;
        this.dispatchEvent( { type: 'rest' } );

    }

    // A `rest` handler may have started a new transition; only sleep when
    // nothing is pending, so `sleep` never fires while the camera moves.
    if ( ! this._needsUpdate ) {

        this.dispatchEvent( { type: 'sleep' } );

    }

}
```

## Verification

- At normal `smoothTime`, `rest` fires from the existing branch and sets `_hasRested`, so the new guard is false → behavior is unchanged.
- With `smoothTime = 0`, a run of transition-enabled moves followed by a settle now drains the accumulated `rest` listeners to `0` instead of stranding one per move.
- A `rest` handler that starts a new transition no longer sees a spurious `sleep` while the camera is moving.
